### PR TITLE
infrastructure: modify prompt

### DIFF
--- a/zephyr-env.cmd
+++ b/zephyr-env.cmd
@@ -7,3 +7,8 @@ if exist "%userprofile%\zephyrrc.cmd" (
 
 rem Zephyr meta-tool (west) launcher alias
 doskey west=py -3 %ZEPHYR_BASE%\scripts\west-win.py $*
+
+echo %PROMPT% | findstr /C:"Zephyr"
+if errorlevel 1 (
+	set PROMPT=(Zephyr) %PROMPT%
+)

--- a/zephyr-env.sh
+++ b/zephyr-env.sh
@@ -67,3 +67,7 @@ unset zephyr_answer_file
 zephyr_answer_file=~/.zephyrrc
 [ -f ${zephyr_answer_file} ] &&  . ${zephyr_answer_file};
 unset zephyr_answer_file
+
+if [[ $PS1 != *"(Zephyr)"* ]]; then
+	export PS1="(Zephyr) "$PS1
+fi


### PR DESCRIPTION
When you have a million terminals open it can be nice easily know which
of the terminals is in the Zephyr environment. This this patch adds a
few lines in the zephyr-env.sh and zephyr-env.cmd files to modify the
prompt when running source zephyr-env.sh or calls the zephyr-env.cmd.
I really don't know how write scripts for the command line in Windows,
but I think the code in zephyr-env.cmd should be correct.

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>