### PR TITLE
Add support for Nordic link layer

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -29,6 +29,13 @@ config BT_LL_SW
 	help
 	  Use Zephyr software BLE Link Layer implementation.
 
+config BT_LL_NORDIC
+	bool "Nordic proprietary BLE Link Layer"
+	depends on NRFXLIB_BLE_CONTROLLER
+	select ZERO_LATENCY_IRQS
+	help
+	  Use Nordic BLE Link Layer implementation.
+
 endchoice
 
 comment "BLE Controller configuration"


### PR DESCRIPTION
This pull request:
- Adds a Kconfig choice under the Bluetooth menu to select Nordic link layer
The choice is only visible if the controller library is enabled.
- ~~Adds a default project configuration for the heart rate example for nrf52_pca10040 boards
to use the controller library.~~

This PR depends on https://github.com/NordicPlayground/nrfxlib/pull/1 and its sibling PR to fw-nrfconnect-nrf: https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/29

@carlescufi 