### PR TITLE
[nrf fromlist] doc: extract_content: Normalize path of ignored folders

### DIFF
--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -111,7 +111,7 @@ def find_content(zephyr_base, src, dest, fnfilter, ignore):
     for dirpath, dirnames, filenames in os.walk(path.join(zephyr_base, src)):
         # Limit the rest of the walk to subdirectories that aren't ignored.
         dirnames[:] = [d for d in dirnames if not
-                       path.join(dirpath, d).startswith(ignore)]
+                       path.normpath(path.join(dirpath, d)).startswith(ignore)]
 
         # If the current directory contains no matching files, keep going.
         sources = fnmatch.filter(filenames, fnfilter)


### PR DESCRIPTION
Normalize the path of ignored folders so that variations in paths
formats on Windows are detected correctly.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>