### PR TITLE
ext: hal: nordic: Add missing peripherals in Kconfig

### DIFF
--- a/ext/hal/nordic/Kconfig
+++ b/ext/hal/nordic/Kconfig
@@ -10,6 +10,9 @@ config HAS_NORDIC_DRIVERS
 config HAS_NRFX
 	bool
 
+config NRFX_PRS
+	bool
+
 config NRFX_ADC
 	bool
 
@@ -24,6 +27,9 @@ config NRFX_PWM
 	bool
 
 config NRFX_QDEC
+	bool
+
+config NRFX_RTC
 	bool
 
 config NRFX_SAADC
@@ -69,6 +75,20 @@ config NRFX_TWI
 
 config NRFX_TWIM
 	bool
+
+config NRFX_UART
+	bool
+
+config NRFX_UARTE
+	bool
+
+config NRFX_UARTE0
+	bool
+	select NRFX_UARTE
+
+config NRFX_UARTE1
+	bool
+	select NRFX_UARTE
 
 config NRFX_USBD
 	bool


### PR DESCRIPTION
Peripheral drivers are already available but cannot be enabled trough
Kconfig. This allow project to use nrfx drivers.

From upstream https://github.com/zephyrproject-rtos/zephyr/commit/9b39be1147a6945649fa73f3ba290025e523ae86

Signed-off-by: Christopher Métrailler <christopher.metrailler@nordicsemi.no>