### PR TITLE
[nrf noup]: arch: arm: fix error with missing casting

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -203,7 +203,7 @@ void arm_core_mpu_configure_user_context(struct k_thread *thread)
 	 * it is essential to include this size increase, to avoid
 	 * MPU faults.
 	 */
-	size += thread->stack_info.start - thread->stack_obj;
+	size += thread->stack_info.start - base;
 #endif
 
 	arm_core_mpu_configure(THREAD_STACK_REGION, base, size);


### PR DESCRIPTION
This commit fixes a compilation error from missing casting.
This will be fixed in upstream, directly, therefore, we add
a no-upstream label in this commit.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>