### PR TITLE
boards: arm: nrf9160: disable entropy driver

### DIFF
--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_defconfig
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_defconfig
@@ -21,3 +21,6 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 # CONFIG_GPIO_AS_PINRESET=y
+
+# entropy driver doesn't support nRF9160 yet
+CONFIG_ENTROPY_NRF5_RNG=n


### PR DESCRIPTION
Current driver implementation doesn't compile for nRF9160, disable it by default.
Needed after changes upstream: https://github.com/zephyrproject-rtos/zephyr/pull/11781