### PR TITLE
boards: arm: nrf9160_pca10090: remove commented config line

### DIFF
--- a/boards/arm/nrf9160_pca10090/nrf9160_pca10090_defconfig
+++ b/boards/arm/nrf9160_pca10090/nrf9160_pca10090_defconfig
@@ -19,8 +19,5 @@ CONFIG_UART_0_NRF_UARTE=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
-# additional board options
-# CONFIG_GPIO_AS_PINRESET=y
-
 # entropy driver doesn't support nRF9160 yet
 CONFIG_ENTROPY_NRF5_RNG=n


### PR DESCRIPTION
Remove commented configuration line.

@barsok, please review this change.
@carlescufi please advise if `[nrf noup]` prefix is appropriate.