### PR TITLE
[nrf noup] ext: nrfx: mdk: Correct imperfectly merged nrf_peripherals.h

### DIFF
--- a/ext/hal/nordic/nrfx/mdk/nrf_peripherals.h
+++ b/ext/hal/nordic/nrfx/mdk/nrf_peripherals.h
@@ -42,7 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #elif defined(__APPLE__)
     /* Do not include nrf specific files when building for PC host */
 #else
-
+    
     #if defined(NRF51)
         #include "nrf51_peripherals.h"
         
@@ -52,9 +52,6 @@ POSSIBILITY OF SUCH DAMAGE.
         #include "nrf52832_peripherals.h"
     #elif defined(NRF52840_XXAA)
         #include "nrf52840_peripherals.h"
-
-    #elif defined (NRF9160_XXAA)
-        #include "nrf9160_peripherals.h"
         
     #elif defined(NRF9160_XXAA)
         #include "nrf9160_peripherals.h"


### PR DESCRIPTION
Apparently changes from commit 941c2bdae4c2225856c2e6ffd2b1a959815d2a17
were not merged perfectly during cherry-picking. Correct the file
so that it is exactly the same as in the MDK package.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>