### PR TITLE
[nrf noup] dts: Add nRF52810 to secureboot.overlay

### DIFF
--- a/dts/common/secureboot.overlay
+++ b/dts/common/secureboot.overlay
@@ -1,32 +1,4 @@
-#ifdef CONFIG_SOC_NRF52840
-&flash0 {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		b0_partition: partition@0 {
-			label = "secure-boot";
-			reg = <0x000000000 0x4000>;
-		};
-		b1_s0_partition: partition@4000 {
-			label = "s0";
-			reg = <0x4000 0xC000>;
-		};
-		b1_s1_partition: partition@10000 {
-			label = "s1";
-			reg = <0x10000 0xC000>;
-		};
-		app_partition: partition@1C000 {
-			label = "app";
-			reg = <0x1C000 0x000E3000>;
-		};
-		provision_partition: partition@FF000 {
-			label = "provision";
-			reg = <0x000FF000 0x00001000>;
-		};
-	};
-};
-#elif CONFIG_SOC_NRF51822_QFAC
+#if defined(CONFIG_SOC_NRF51822_QFAA) || defined(CONFIG_SOC_NRF51822_QFAC)
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";
@@ -51,6 +23,34 @@
 		provision_partition: partition@3F000 {
 			label = "provision";
 			reg = <0x0003F000 0x00001000>;
+		};
+	};
+};
+#elif CONFIG_SOC_NRF52810
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		b0_partition: partition@0 {
+			label = "secure-boot";
+			reg = <0x000000000 0x4000>;
+		};
+		b1_s0_partition: partition@4000 {
+			label = "s0";
+			reg = <0x4000 0xC000>;
+		};
+		b1_s1_partition: partition@10000 {
+			label = "s1";
+			reg = <0x10000 0xC000>;
+		};
+		app_partition: partition@1C000 {
+			label = "app";
+			reg = <0x1C000 0x00013000>;
+		};
+		provision_partition: partition@2F000 {
+			label = "provision";
+			reg = <0x0002F000 0x00001000>;
 		};
 	};
 };
@@ -79,6 +79,34 @@
 		provision_partition: partition@7F000 {
 			label = "provision";
 			reg = <0x0007F000 0x00001000>;
+		};
+	};
+};
+#elif CONFIG_SOC_NRF52840
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		b0_partition: partition@0 {
+			label = "secure-boot";
+			reg = <0x000000000 0x4000>;
+		};
+		b1_s0_partition: partition@4000 {
+			label = "s0";
+			reg = <0x4000 0xC000>;
+		};
+		b1_s1_partition: partition@10000 {
+			label = "s1";
+			reg = <0x10000 0xC000>;
+		};
+		app_partition: partition@1C000 {
+			label = "app";
+			reg = <0x1C000 0x000E3000>;
+		};
+		provision_partition: partition@FF000 {
+			label = "provision";
+			reg = <0x000FF000 0x00001000>;
 		};
 	};
 };


### PR DESCRIPTION
This provides support for BOARD=nrf52810_pca10040.