### PR TITLE
[nrf noup] add field required for http DFU client

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -68,6 +68,7 @@ enum net_ip_protocol_secure {
 /* Protocol numbers for LTE protocols */
 enum net_lte_protocol {
 	NPROTO_AT = 513,
+	NPROTO_DFU = 515,
 };
 
 /** Socket type */


### PR DESCRIPTION
Add fields required for HTTP GET DFU protocol.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>