### PR TITLE
[nrf noup] scripts: west: nrfjprog: Support nRF91

### DIFF
--- a/scripts/meta/west/runners/nrfjprog.py
+++ b/scripts/meta/west/runners/nrfjprog.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2017 Linaro Limited.
+# Copyright (c) 2019 Nordic Semiconductor ASA.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -7,6 +8,7 @@
 import sys
 
 from west import log
+
 from west.runners.core import ZephyrBinaryRunner, RunnerCaps
 
 
@@ -32,7 +34,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def do_add_parser(cls, parser):
         parser.add_argument('--nrf-family', required=True,
-                            choices=['NRF51', 'NRF52'],
+                            choices=['NRF51', 'NRF52', 'NRF91'],
                             help='family of nRF MCU')
         parser.add_argument('--softreset', required=False,
                             action='store_true',
@@ -103,10 +105,10 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                 program_cmd
             ])
         else:
-            if self.family == 'NRF51':
-                commands.append(program_cmd + ['--sectorerase'])
-            else:
+            if self.family == 'NRF52':
                 commands.append(program_cmd + ['--sectoranduicrerase'])
+            else:
+                commands.append(program_cmd + ['--sectorerase'])
 
         if self.family == 'NRF52' and not self.softreset:
             commands.extend([


### PR DESCRIPTION
This file will disappear when we upmerge next, but we need this fix in
the meantime to be able to flash the nRF91.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>