### PR TITLE
[nrf noup]: logging: Logger fixes

### DIFF
--- a/include/misc/__assert.h
+++ b/include/misc/__assert.h
@@ -81,16 +81,7 @@
 
 #if __ASSERT_ON
 #include <misc/printk.h>
-
-#if defined(CONFIG_ARCH_POSIX)
-extern void posix_exit(int exit_code);
-#define __ASSERT_POST posix_exit(1)
-#else
-#define __ASSERT_POST             \
-	for (;;) {                \
-		/* spin thread */ \
-	}
-#endif
+void assert_post_action(void);
 
 #define __ASSERT_LOC(test)                               \
 	printk("ASSERTION FAIL [%s] @ %s:%d\n",    \
@@ -102,7 +93,7 @@ extern void posix_exit(int exit_code);
 	do {                                                             \
 		if (!(test)) {                                           \
 			__ASSERT_LOC(test);                              \
-			__ASSERT_POST;                                   \
+			assert_post_action();                            \
 		}                                                        \
 	} while (false)
 
@@ -110,8 +101,8 @@ extern void posix_exit(int exit_code);
 	do {                                                             \
 		if (!(test)) {                                           \
 			__ASSERT_LOC(test);                              \
-			printk("\t" fmt "\n", ##__VA_ARGS__);      \
-			__ASSERT_POST;                                   \
+			printk("\t" fmt "\n", ##__VA_ARGS__);            \
+			assert_post_action();                            \
 		}                                                        \
 	} while (false)
 

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -17,3 +17,5 @@ zephyr_sources_ifdef(CONFIG_JSON_LIBRARY json.c)
 zephyr_sources_if_kconfig(printk.c)
 
 zephyr_sources_if_kconfig(ring_buffer.c)
+
+zephyr_sources_ifdef(CONFIG_ASSERT assert.c)

--- a/lib/os/assert.c
+++ b/lib/os/assert.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <misc/__assert.h>
+#include <zephyr.h>
+
+void assert_post_action(void)
+{
+	if (IS_ENABLED(CONFIG_ARCH_POSIX)) {
+		extern void posix_exit(int exit_code);
+		posix_exit(1);
+	} else {
+		k_panic();
+	}
+}

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -319,6 +319,11 @@ void log_panic(void)
 		return;
 	}
 
+	/* If panic happend early logger might not be initialized.
+	 * Forcing initialization of the logger and auto-starting backends.
+	 */
+	log_init();
+
 	for (int i = 0; i < log_backend_count_get(); i++) {
 		backend = log_backend_get(i);
 


### PR DESCRIPTION
This PR includes fixes for following issues:
* asserts not printed
* device hangs on going to deep sleep mode when JLink is not connected

Fixes are needed to enable proper automated testing on nRF52 Desktop devices.

With the next mergeup, these commits shouldn't be included anymore (they come from upstream).