### PR TITLE
[DNM] drivers: flash: soc_flash_nrf: add support for nrf9160

### DIFF
--- a/include/net/socket_offload.h
+++ b/include/net/socket_offload.h
@@ -158,20 +158,7 @@ static inline void freeaddrinfo(struct addrinfo *res)
 	return socket_ops->freeaddrinfo(res);
 }
 
-static inline int fcntl(int fd, int cmd, ...)
-{
-	__ASSERT_NO_MSG(socket_ops);
-	__ASSERT_NO_MSG(socket_ops->fcntl);
-
-	va_list args;
-	int res;
-
-	va_start(args, cmd);
-	res = socket_ops->fcntl(fd, cmd, args);
-	va_end(args);
-
-	return res;
-}
+int fcntl(int fd, int cmd, ...);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/sockets/socket_offload.c
+++ b/subsys/net/lib/sockets/socket_offload.c
@@ -20,3 +20,17 @@ void socket_offload_register(const struct socket_offload *ops)
 	socket_ops = ops;
 }
 
+int fcntl(int fd, int cmd, ...)
+{
+	__ASSERT_NO_MSG(socket_ops);
+	__ASSERT_NO_MSG(socket_ops->fcntl);
+
+	va_list args;
+	int res;
+
+	va_start(args, cmd);
+	res = socket_ops->fcntl(fd, cmd, args);
+	va_end(args);
+
+	return res;
+}


### PR DESCRIPTION
This PR is intended to give visibility to the workaround to necessary to use Zephyr's flash driver on nRF9160.

FYI: @gbakke @osaether 