### PR TITLE
[nrf temphack] include: arm: linker.ld

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -172,6 +172,11 @@ SECTIONS
 	KEEP(*(".kinetis_flash_config.*"))
 
 	_vector_end = .;
+	/* This is used for Secure Boot */
+	#if defined(CONFIG_SECURE_BOOT)
+	. = CONFIG_SB_FIRMWARE_INFO_OFFSET;
+	KEEP(*(.firmware_info))
+	#endif
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION


### PR DESCRIPTION
Fix up for linker script to place firmware metadata in the built hexfile
for secure bootloader.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>