### PR TITLE
[nrf fromlist] ext: encoding: tinycbor: Add missing files for pretty …

### DIFF
--- a/ext/lib/encoding/tinycbor/CMakeLists.txt
+++ b/ext/lib/encoding/tinycbor/CMakeLists.txt
@@ -12,5 +12,7 @@ zephyr_library_sources(
 )
 zephyr_library_sources_ifdef(CONFIG_NEWLIB_LIBC src/cborparser_dup_string.c)
 
+zephyr_library_sources_ifdef(CONFIG_CBOR_PRETTY_PRINTING src/cborpretty.c)
+
 zephyr_library_link_libraries(TINYCBOR)
 target_link_libraries(TINYCBOR INTERFACE zephyr_interface)

--- a/ext/lib/encoding/tinycbor/Kconfig
+++ b/ext/lib/encoding/tinycbor/Kconfig
@@ -68,4 +68,9 @@ config CBOR_WITHOUT_OPEN_MEMSTREAM
 	help
 	  This option enables open memstream support.
 
+config CBOR_PRETTY_PRINTING
+	bool "Implement pretty printing functionality"
+	help
+	  This option enables cbor_value_to_pretty_stream function.
+
 endif #TINYCBOR


### PR DESCRIPTION
…printing

Source PR: https://github.com/zephyrproject-rtos/zephyr/pull/13820

This commits adds missing source files for tinycbor
library to allow pretty printing.

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>