### PR TITLE
[RFC] cmake: Add Cmake function for adding named sections to the linker file

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -79,8 +79,8 @@ void z_arch_configure_static_mpu_regions(void)
 #if defined(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
 		const struct k_mem_partition ramfunc_region =
 		{
-		.start = (u32_t)&_ramfunc_ram_start,
-		.size = (u32_t)&_ramfunc_ram_size,
+		.start = (u32_t)&__ramfunc_start,
+		.size = (u32_t)&__ramfunc_size,
 		.attr = K_MEM_PARTITION_P_RX_U_RX,
 		};
 #endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */

--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -12,3 +12,16 @@ zephyr_sources_ifdef(
   CONFIG_EXECUTION_BENCHMARKING
   timing_info_bench.c
   )
+
+if (DEFINED CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
+  add_named_section(
+    ".ramfunc"
+    REGION
+    "RAMABLE_REGION"
+    LOAD_REGION
+    "ROMABLE_REGION"
+    MPU_ALIGN
+    INPUT_SECTIONS
+    "*(.ramfunc)"
+    "*(\".ramfunc.*\")")
+endif()

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -472,45 +472,6 @@ SECTIONS
 
     GROUP_END(RAMABLE_REGION)
 
-#ifdef DT_CCM_BASE_ADDRESS
-
-    GROUP_START(CCM)
-
-	SECTION_PROLOGUE(_CCM_BSS_SECTION_NAME, (NOLOAD OPTIONAL),SUBALIGN(4))
-	{
-		__ccm_start = .;
-		__ccm_bss_start = .;
-		*(.ccm_bss)
-		*(".ccm_bss.*")
-	} GROUP_LINK_IN(CCM)
-
-	__ccm_bss_end = .;
-
-	SECTION_PROLOGUE(_CCM_NOINIT_SECTION_NAME, (NOLOAD OPTIONAL),SUBALIGN(4))
-	{
-		__ccm_noinit_start = .;
-		*(.ccm_noinit)
-		*(".ccm_noinit.*")
-	} GROUP_LINK_IN(CCM)
-
-	__ccm_noinit_end = .;
-
-	SECTION_PROLOGUE(_CCM_DATA_SECTION_NAME, (OPTIONAL),SUBALIGN(4))
-	{
-		__ccm_data_start = .;
-		*(.ccm_data)
-		*(".ccm_data.*")
-	} GROUP_LINK_IN(CCM AT> ROMABLE_REGION)
-
-	__ccm_data_end = .;
-	__ccm_end = .;
-
-	__ccm_data_rom_start = LOADADDR(_CCM_DATA_SECTION_NAME);
-
-    GROUP_END(CCM)
-
-#endif /* DT_CCM_BASE_ADDRESS */
-
 #ifdef CONFIG_CUSTOM_SECTIONS_LD
 /* Located in project source directory */
 #include <custom-sections.ld>

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -367,20 +367,6 @@ SECTIONS
 	_nocache_ram_size = _nocache_ram_end - _nocache_ram_start;
 #endif /* CONFIG_NOCACHE_MEMORY */
 
-#if defined(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
-	SECTION_DATA_PROLOGUE(.ramfunc,,)
-	{
-		MPU_ALIGN(_ramfunc_ram_size);
-		_ramfunc_ram_start = .;
-		*(.ramfunc)
-		*(".ramfunc.*")
-		MPU_ALIGN(_ramfunc_ram_size);
-		_ramfunc_ram_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-	_ramfunc_ram_size = _ramfunc_ram_end - _ramfunc_ram_start;
-	_ramfunc_rom_start = LOADADDR(.ramfunc);
-#endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
-
 /* Located in generated directory. This file is populated by the
  * add_named_section() Cmake function. */
 #include <generated-sections-ram.ld>

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -286,14 +286,6 @@ SECTIONS
 
     GROUP_END(ROMABLE_REGION)
 
-/* Some TI SoCs have a special configuration footer, at the end of flash. */
-#ifdef CONFIG_TI_CCFG_PRESENT
-    SECTION_PROLOGUE(.ti_ccfg,,)
-    {
-    KEEP(*(TI_CCFG))
-    } > FLASH_CCFG
-#endif
-
     /*
      * These are here according to 'arm-zephyr-elf-ld --verbose',
      * before data section.

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -389,6 +389,10 @@ SECTIONS
 	_ramfunc_rom_start = LOADADDR(.ramfunc);
 #endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 
+/* Located in generated directory. This file is populated by the
+ * add_named_section() Cmake function. */
+#include <generated-sections-ram.ld>
+
 #if defined(CONFIG_USERSPACE)
 #define APP_SHARED_ALIGN . = ALIGN(_region_min_align);
 #define SMEM_PARTITION_ALIGN MPU_ALIGN
@@ -519,6 +523,10 @@ SECTIONS
 /* Located in project source directory */
 #include <custom-sections.ld>
 #endif
+
+/* Located in generated directory. This file is populated by the
+ * add_named_section() Cmake function. */
+#include <generated-sections.ld>
 
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <linker/intlist.ld>

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -246,10 +246,10 @@ extern char _nocache_ram_size[];
  * section, stored in RAM instead of FLASH.
  */
 #ifdef CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
-extern char _ramfunc_ram_start[];
-extern char _ramfunc_ram_end[];
-extern char _ramfunc_ram_size[];
-extern char _ramfunc_rom_start[];
+extern char __ramfunc_start[];
+extern char __ramfunc_end[];
+extern char __ramfunc_size[];
+extern char __ramfunc_rom_start[];
 #endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 
 #endif /* ! _ASMLANGUAGE */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -178,8 +178,8 @@ void z_data_copy(void)
 	(void)memcpy(&__data_ram_start, &__data_rom_start,
 		 ((u32_t) &__data_ram_end - (u32_t) &__data_ram_start));
 #ifdef CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
-	(void)memcpy(&_ramfunc_ram_start, &_ramfunc_rom_start,
-		 ((u32_t) &_ramfunc_ram_size));
+	(void)memcpy(&__ramfunc_start, &__ramfunc_rom_start,
+		 ((u32_t) &__ramfunc_size));
 #endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 #ifdef DT_CCM_BASE_ADDRESS
 	(void)memcpy(&__ccm_data_start, &__ccm_data_rom_start,

--- a/soc/arm/st_stm32/common/CMakeLists.txt
+++ b/soc/arm/st_stm32/common/CMakeLists.txt
@@ -1,2 +1,8 @@
 zephyr_sources_ifdef(CONFIG_ARM_MPU arm_mpu_regions.c)
 zephyr_sources(stm32cube_hal.c)
+
+if (DEFINED DT_CCM_BASE_ADDRESS)
+  add_named_section(".ccm_bss" REGION CCM GROUP_START CCM)
+  add_named_section(".ccm_noinit" REGION CCM)
+  add_named_section(".ccm_data" REGION "CCM\ AT\>\ ROMABLE_REGION" GROUP_END CCM)
+endif()

--- a/soc/arm/ti_simplelink/cc2650/CMakeLists.txt
+++ b/soc/arm/ti_simplelink/cc2650/CMakeLists.txt
@@ -1,1 +1,3 @@
 zephyr_sources(soc.c)
+add_named_section(".ti_ccfg" REGION FLASH_CCFG INPUT_SECTIONS "KEEP(*(TI_CCFG))")
+


### PR DESCRIPTION
Call add_named_section(".foo") to add a FLASH section with the name .foo.
Will also create the symbols _foo_start, _foo_end, and _foo_size.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>