### PR TITLE
[nrf temphack] cmake: kconfig: Support building without kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,7 +573,7 @@ endif()
 add_subdirectory(boards)
 add_subdirectory(ext)
 add_subdirectory(subsys)
-add_subdirectory(drivers)
+add_subdirectory_ifdef(CONFIG_KERNEL drivers)
 
 # Add all zephyr modules subdirectories.
 if(ZEPHYR_MODULES_NAME)

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -44,6 +44,10 @@ menu "Build and Link Features"
 
 menu "Linker Options"
 
+config KERNEL
+	bool "Include Zephyr kernel"
+	default y
+
 choice
 	prompt "Linker Orphan Section Handling"
 	default LINKER_ORPHAN_SECTION_WARN

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_definitions(-D__ZEPHYR_SUPERVISOR__)
 
 add_subdirectory(common)
-add_subdirectory(${ARCH_DIR}/${ARCH} arch/${ARCH})
+add_subdirectory_ifdef(CONFIG_KERNEL ${ARCH_DIR}/${ARCH} arch/${ARCH})


### PR DESCRIPTION
Certain components (e.g. bootloaders) will get conflicts
with symbols defined in 'drivers' and 'arch', create kconfig
which allows them to opt out of these.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>