### PR TITLE
[nrf temphack] cortex_m: linker: Add ext_abi section

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -252,6 +252,11 @@ SECTIONS
 #include <linker/priv_stacks-rom.ld>
 #include <linker/kobject-rom.ld>
 
+	. = ALIGN(4);
+	_ext_abis_start = .;
+	KEEP(*(.ext_abis))
+	_ext_abis_size = ABSOLUTE((. - _ext_abis_start) / 4);
+
 	/*
 	 * For XIP images, in order to avoid the situation when __data_rom_start
 	 * is 32-bit aligned, but the actual data is placed right after rodata


### PR DESCRIPTION
This will be changed when linker snippets (PR #109) is merged.

This change is required for https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/556, because it seems unlikely that #109 will be merged in the near future. If and when #109 is merged, this change is no longer needed.