### PR TITLE
cmake: re-apply patch needed for multi image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,7 +591,7 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
     string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" module_name ${module})
     string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" module_path ${module})
     message("Including module: ${module_name} in path: ${module_path}")
-    add_subdirectory(${module_path} ${CMAKE_BINARY_DIR}/${module_name})
+    add_subdirectory(${module_path} ${CMAKE_CURRENT_BINARY_DIR}/${module_name})
   endforeach()
 endif()
 


### PR DESCRIPTION
Without this patch multi image builds will fail
as the modules' build directories are the same
for each image, resulting in an error.

With this patch, each module build dir is placed
within each images build dir, making them unique.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>