### PR TITLE
[nrf toup] cmake: zephyr_modules: Add west executable argument

### DIFF
--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -20,12 +20,17 @@ endif()
 
 set(KCONFIG_MODULES_FILE ${CMAKE_BINARY_DIR}/Kconfig.modules)
 
+if(WEST)
+  set(WEST_ARG "--west-path" ${WEST})
+endif()
+
 if(WEST OR ZEPHYR_MODULES)
   # Zephyr module uses west, so only call it if west is installed or
   # ZEPHYR_MODULES was provided as argument to CMake.
   execute_process(
     COMMAND
     ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/zephyr_module.py
+    ${WEST_ARG}
     ${ZEPHYR_MODULES_ARG}
     ${ZEPHYR_EXTRA_MODULES_ARG}
     --kconfig-out ${KCONFIG_MODULES_FILE}

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -119,12 +119,14 @@ def main():
                              'list`')
     parser.add_argument('-x', '--extra-modules', nargs='+',
                         help='List of extra modules to parse')
+    parser.add_argument('-w', '--west-path', help='Path to west executable')
     args = parser.parse_args()
 
     if args.modules is None:
-        p = subprocess.Popen(['west', 'list', '--format={posixpath}'],
+        p = subprocess.Popen([args.west_path, 'list', '--format={posixpath}'],
                              stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+                             stderr=subprocess.PIPE,
+                             )
         out, err = p.communicate()
         if p.returncode == 0:
             projects = out.decode(sys.getdefaultencoding()).splitlines()


### PR DESCRIPTION
On some systems where you don't have access to `PATH` and you can't set the `ENV{PATH}` variable to what you need it to be. This means that the path where west is won't be passed down to the python script this should have been set explicit.

This is a bugfix to get NCS to work with SES on OSX