### PR TITLE
[nrf toup] tests: drivers: counter: Add clock stabilization nRF

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -7,6 +7,10 @@
 #include <counter.h>
 #include <ztest.h>
 #include <kernel.h>
+#ifdef CONFIG_SOC_FAMILY_NRF
+#include <drivers/clock_control/nrf_clock_control.h>
+#include <clock_control.h>
+#endif
 
 static volatile u32_t top_cnt;
 static volatile u32_t alarm_cnt;
@@ -81,6 +85,16 @@ typedef void (*counter_test_func_t)(const char *dev_name);
 
 static void counter_setup_instance(const char *dev_name)
 {
+#ifdef CONFIG_SOC_FAMILY_NRF
+	struct device *clock =
+			device_get_binding(DT_NORDIC_NRF_CLOCK_0_LABEL "_32K");
+
+	__ASSERT_NO_MSG(clock);
+
+	while (clock_control_on(clock, (void *)CLOCK_CONTROL_NRF_K32SRC) != 0) {
+		/* empty */
+	}
+#endif
 	alarm_cnt = 0U;
 }
 


### PR DESCRIPTION
Xtal LF clock source starts hundreds of milliseconds. When it is
not start, test may fail due to wrong timing. Added pending
on LF clock being start in test setup.

Fix is part of PR: https://github.com/zephyrproject-rtos/zephyr/pull/15623

Fixes broken counter test on pca10040.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>