### PR TITLE
cmake: depend on file AND wrapper target for merged_to_sign

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -89,7 +89,7 @@ if(FIRST_BOILERPLATE_EXECUTION)
       # Special handling needed to merge before signing.
       set(merged_to_sign_hex ${PROJECT_BINARY_DIR}/merged_to_sign.hex)
       add_custom_command(
-        OUTPUT ${PROJECT_BINARY_DIR}/merged_to_sign.hex
+        OUTPUT ${merged_to_sign_hex}
         COMMAND
         ${PYTHON_EXECUTABLE}
         ${ZEPHYR_BASE}/scripts/mergehex.py
@@ -111,6 +111,7 @@ if(FIRST_BOILERPLATE_EXECUTION)
         TARGET partition_manager
         PROPERTY MCUBOOT_TO_SIGN_DEPENDS
         merged_to_sign_target
+        ${merged_to_sign_hex}
         )
     endif()
   endif()


### PR DESCRIPTION
In some corner cases, it is required to depend on both
the wrapper target for a file generated through add_custom_command
AND the file being generated.

Prior to this fix, the dependency from 'merged_to_sign.hex'
to 'signed.hex' was not being enforced. This resulted in
outdated 'merged.hex' files when re-building.

This commit fixes this dependency, making a re-build
correctly re-generate the 'signed.hex' and hence 'merged.hex'.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>