### PR TITLE
[nrf noup] ci: limit build agent selection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   agent {
     docker {
       image "$IMAGE_TAG"
-      label "docker && ncs"
+      label "docker && build-node && ncs"
       args '-e PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/workdir/.local/bin'
     }
   }


### PR DESCRIPTION
Only build agent should be used for building jobs.

Signed-off-by: Chris Bittner <chris.bittner@nordicsemi.no>