### PR TITLE
[nrf toup] cmake: Improve access to other images in multi-image builds.

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -87,6 +87,12 @@ set(__build_dir ${CMAKE_CURRENT_BINARY_DIR}/zephyr)
 
 set(PROJECT_BINARY_DIR ${__build_dir})
 
+define_property(GLOBAL PROPERTY ${IMAGE}PROJECT_BINARY_DIR
+  BRIEF_DOCS "Build directory (PROJECT_BINARY_DIR) for the ${IMAGE} image."
+  FULL_DOCS "To be used to access e.g. this image's hex file."
+  )
+set_property(GLOBAL PROPERTY ${IMAGE}PROJECT_BINARY_DIR ${PROJECT_BINARY_DIR})
+
 add_custom_target(${IMAGE}code_data_relocation_target)
 
 # CMake's 'project' concept has proven to not be very useful for Zephyr

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -889,6 +889,12 @@ function(import_kconfig prefix kconfig_fragment)
   endforeach()
 endfunction()
 
+function(get_image_name image out_var)
+  string(LENGTH ${image} len)
+  MATH(EXPR len "${len}-1")
+  string(SUBSTRING ${image} 0 ${len} ${out_var})
+endfunction()
+
 ########################################################
 # 3. CMake-generic extensions
 ########################################################


### PR DESCRIPTION
Global properties:
 - ${IMAGE}PROJECT_BINARY_DIR.

Helper function:
 - get_image_name() to strip the '_'.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>