### PR TITLE
[nrf toup] cmake: fix regex for west version check in host-tools.cmake

### DIFF
--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -25,7 +25,7 @@ else()
   # via pypi, which will result in a single line of output.
   string(REGEX REPLACE "\n" ";" west_version_output "${west_version_output}")
   foreach(item ${west_version_output})
-    if("${item}" MATCHES ".*v([0-9]+[.][0-9]+[.][0-9]+)")
+    if("${item}" MATCHES "^[^\/\\]*v([0-9]+[.][0-9]+[.][0-9]+)")
       set(west_version "${CMAKE_MATCH_1}")
       if(${west_version} VERSION_LESS ${MIN_WEST_VERSION})
         message(FATAL_ERROR "The detected west version is unsupported.\n\


### PR DESCRIPTION
This change enables the nrfconnect CI to test tags.  

'west --version' output has the path to the west manifest directory along with the version.
If there is a semantic version string in this path name (like when CI tests a tag), it raises
a false version check failure.