### PR TITLE
Extra changes for Non-Secure Callable support

### DIFF
--- a/arch/arm/core/cortex_m/tz/CMakeLists.txt
+++ b/arch/arm/core/cortex_m/tz/CMakeLists.txt
@@ -4,6 +4,8 @@
 # Security Extensions. This option is required when building a Secure firmware.
 zephyr_compile_options_ifdef(CONFIG_ARM_SECURE_FIRMWARE -mcmse)
 
+set(veneers_lib_path ${CMAKE_BINARY_DIR}/${CONFIG_ARM_ENTRY_VENEERS_LIB_NAME})
+
 if(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
 
   # --out-implib and --cmse-implib instruct the linker to produce
@@ -12,7 +14,7 @@ if(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
   # when building a Non-Secure image which shall have access to Secure
   # Entry functions.
   zephyr_ld_options(
-    ${LINKERFLAGPREFIX},--out-implib=${CMAKE_BINARY_DIR}/${CONFIG_ARM_ENTRY_VENEERS_LIB_NAME}
+    ${LINKERFLAGPREFIX},--out-implib=${veneers_lib_path}
   )
 
   zephyr_ld_options(
@@ -23,13 +25,22 @@ if(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
   set_property(
     GLOBAL APPEND PROPERTY
     ${IMAGE}extra_post_build_byproducts
-    ${CMAKE_BINARY_DIR}/${CONFIG_ARM_ENTRY_VENEERS_LIB_NAME}
+    ${veneers_lib_path}
     )
+
+  # Add wrapper target for the benefit of make.
+  add_custom_target(nsc_veneers
+    DEPENDS
+    ${veneers_lib_path}
+    ${ZEPHYR_FINAL_EXECUTABLE})
 endif()
 
-# Link the entry veneers library file with the Non-Secure Firmware that needs it.
-zephyr_link_libraries_ifdef(CONFIG_ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS
-  ${CMAKE_BINARY_DIR}/${CONFIG_ARM_ENTRY_VENEERS_LIB_NAME}
-  )
+if (CONFIG_ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS)
+  # Link the entry veneers library file with the Non-Secure Firmware that needs it.
+  zephyr_link_libraries(${veneers_lib_path})
+
+  # Add dependency for the benefit of make.
+  add_dependencies(${IMAGE}zephyr_interface nsc_veneers)
+endif()
 
 zephyr_sources_ifdef(CONFIG_ARM_SECURE_FIRMWARE arm_core_tz.c)


### PR DESCRIPTION
 1. Seamlessly call into secure zone to do reboot.
 2. Add extra Cmake target so SPM builds before app when using secure entry functions.