### PR TITLE
ci: Skip Kconfig compliance check temporarily

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,18 +62,31 @@ pipeline {
             dir('zephyr') {
               script {
                 // If we're a pull request, compare the target branch against the current HEAD (the PR)
+                println "CHANGE_TARGET = ${env.CHANGE_TARGET}"
+                println "BRANCH_NAME = ${env.BRANCH_NAME}"
+                println "TAG_NAME = ${env.TAG_NAME}"
+
                 if (env.CHANGE_TARGET) {
-                  COMMIT_RANGE = "origin/$CHANGE_TARGET..HEAD"
+                  COMMIT_RANGE = "origin/${env.CHANGE_TARGET}..HEAD"
                   COMPLIANCE_ARGS = "$COMPLIANCE_ARGS $COMPLIANCE_REPORT_ARGS"
                   sh "echo change id: $CHANGE_ID"
                   sh "echo git commit: $GIT_COMMIT"
                   sh "echo commit range: $COMMIT_RANGE"
                   sh "git rev-parse origin/$CHANGE_TARGET"
                   sh "git rev-parse HEAD"
+                  println "Building a PR: ${COMMIT_RANGE}"
+                }
+                else if (env.TAG_NAME) {
+                  COMMIT_RANGE = "tags/${env.BRANCH_NAME}..tags/${env.BRANCH_NAME}"
+                  println "Building a Tag: ${COMMIT_RANGE}"
                 }
                 // If not a PR, it's a non-PR-branch or master build. Compare against the origin.
-                else {
+                else if (env.BRANCH_NAME) {
                   COMMIT_RANGE = "origin/${env.BRANCH_NAME}..HEAD"
+                  println "Building a Branch: ${COMMIT_RANGE}"
+                }
+                else {
+                    assert condition : "Build fails because it is not a PR/Tag/Branch"
                 }
                 // Run the compliance check
                 try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
       // ENVs for check-compliance
       GH_TOKEN = credentials('nordicbuilder-compliance-token') // This token is used to by check_compliance to comment on PRs and use checks
       GH_USERNAME = "NordicBuilder"
-      COMPLIANCE_ARGS = "-r NordicPlayground/fw-nrfconnect-zephyr"
+      COMPLIANCE_ARGS = "-r NordicPlayground/fw-nrfconnect-zephyr --exclude-module Kconfig"
       COMPLIANCE_REPORT_ARGS = "-p $CHANGE_ID -S $GIT_COMMIT -g"
 
       LC_ALL = "C.UTF-8"


### PR DESCRIPTION
    
    
    This is a temporary fix. We will find a permanent solution after v1.0.0 release.
