### PR TITLE
[nrf noup] cmake: Automatic board change for PCA20035

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -269,6 +269,11 @@ else() # NOT FIRST_BOILERPLATE_EXECUTION
     message("Changed board to secure nrf9160_pca10090 (NOT NS)")
   endif()
 
+  if(${BOARD} STREQUAL nrf9160_pca20035ns)
+    set(BOARD nrf9160_pca20035)
+    message("Changed board to secure nrf9160_pca20035 (NOT NS)")
+  endif()
+
   unset(${IMAGE}DTC_OVERLAY_FILE)
   if(EXISTS              ${APPLICATION_SOURCE_DIR}/${BOARD}.overlay)
     set(${IMAGE}DTC_OVERLAY_FILE ${APPLICATION_SOURCE_DIR}/${BOARD}.overlay)


### PR DESCRIPTION
This is done so that sub-images of a nrf9160_pca20035ns image
are built as secure.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>