### PR TITLE
[nrf toup] arch: Allow removing drivers while keeping arch and kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,7 @@ endif()
 add_subdirectory(boards)
 add_subdirectory(ext)
 add_subdirectory(subsys)
-add_subdirectory_ifdef(CONFIG_KERNEL drivers)
+add_subdirectory(drivers)
 
 # Include zephyr modules generated CMake file.
 if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,7 @@ endif()
 add_subdirectory(boards)
 add_subdirectory(ext)
 add_subdirectory(subsys)
-add_subdirectory(drivers)
+add_subdirectory_ifdef(CONFIG_DRIVERS drivers)
 
 # Include zephyr modules generated CMake file.
 if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -50,10 +50,6 @@ menu "Build and Link Features"
 
 menu "Linker Options"
 
-config KERNEL
-	bool "Include Zephyr kernel"
-	default y
-
 choice
 	prompt "Linker Orphan Section Handling"
 	default LINKER_ORPHAN_SECTION_WARN

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -50,6 +50,10 @@ menu "Build and Link Features"
 
 menu "Linker Options"
 
+config DRIVERS
+	bool "Include drivers"
+	default y
+
 choice
 	prompt "Linker Orphan Section Handling"
 	default LINKER_ORPHAN_SECTION_WARN

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -3,4 +3,4 @@
 add_definitions(-D__ZEPHYR_SUPERVISOR__)
 
 add_subdirectory(common)
-add_subdirectory_ifdef(CONFIG_KERNEL ${ARCH_DIR}/${ARCH} arch/${ARCH})
+add_subdirectory(${ARCH_DIR}/${ARCH} arch/${ARCH})

--- a/arch/arm/core/CMakeLists.txt
+++ b/arch/arm/core/CMakeLists.txt
@@ -23,6 +23,10 @@ zephyr_library_sources(
   thread_abort.c
 )
 
+if (NOT DEFINED CONFIG_DRIVERS)
+  zephyr_library_sources(zephyr_dummy_interrupt_handlers.c)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_GEN_SW_ISR_TABLE isr_wrapper.S)
 zephyr_library_sources_ifdef(CONFIG_CPLUSPLUS __aeabi_atexit.c)
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)

--- a/arch/arm/core/zephyr_dummy_interrupt_handlers.c
+++ b/arch/arm/core/zephyr_dummy_interrupt_handlers.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+void dummy_handler(void)
+{
+	/* Hang on unexpected faults and interrupts as it's considered
+	 * a bug in the program.
+	 */
+	while (1) {
+		;
+	}
+}
+
+/* Weakly assign all interrupt handlers to dummy_handler */
+#define ALIAS_DUMMY __attribute__((weak, alias("dummy_handler")))
+
+void __nmi(void) ALIAS_DUMMY;
+void __hard_fault(void) ALIAS_DUMMY;
+#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+void __mpu_fault(void) ALIAS_DUMMY;
+void __bus_fault(void) ALIAS_DUMMY;
+void __usage_fault(void) ALIAS_DUMMY;
+void __debug_monitor(void) ALIAS_DUMMY;
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+void __secure_fault(void) ALIAS_DUMMY;
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
+#endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
+void __svc(void) ALIAS_DUMMY;
+void __pendsv(void) ALIAS_DUMMY;
+void __sys_tick(void) ALIAS_DUMMY;
+void z_clock_isr(void) ALIAS_DUMMY;

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -23,6 +23,16 @@ static struct k_spinlock timeout_lock;
 
 static bool can_wait_forever;
 
+__weak u32_t z_clock_elapsed(void)
+{
+	k_oops();
+}
+
+__weak void z_clock_set_timeout(s32_t ticks, bool idle)
+{
+	k_oops();
+}
+
 /* Cycles left to process in the currently-executing z_clock_announce() */
 static int announce_remaining;
 


### PR DESCRIPTION
Add dummy interrupt handlers and driver functions.
Rename CONFIG_KERNEL to CONFIG_DRIVERS and have it affect drivers only.

This helps with porting B0 to use more native Zephyr code.