### PR TITLE
[nrf noup] linker.ld: Change ifdef from SECURE_BOOT to FW_METADATA

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -188,8 +188,8 @@ SECTIONS
 
 	_vector_end = .;
 	/* This is used for Secure Boot */
-	#if defined(CONFIG_SECURE_BOOT)
-	. = CONFIG_SB_FIRMWARE_INFO_OFFSET;
+	#if defined(CONFIG_FW_METADATA)
+	. = CONFIG_FW_FIRMWARE_INFO_OFFSET;
 	KEEP(*(.firmware_info))
 	#endif
 	} GROUP_LINK_IN(ROMABLE_REGION)


### PR DESCRIPTION
FW_METADATA is its own subsys now.
This improves user experience with B0 + MCUboot.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>