### PR TITLE
[nrf noup] ci: use Standard Library in Jenkinsfile to link sub-projects together

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,28 @@
-def IMAGE_TAG = "ncs-toolchain:1.08"
+
+@Library("CI_LIB@lib_master") _
+
+def IMAGE_TAG = lib_Main.getDockerImage(JOB_NAME)
+def AGENT_LABELS = lib_Main.getAgentLabels(JOB_NAME)
 def REPO_CI_TOOLS = "https://github.com/zephyrproject-rtos/ci-tools.git"
 def REPO_CI_TOOLS_SHA = "bfe635f102271a4ad71c1a14824f9d5e64734e57"
+def CI_STATE = new HashMap()
 
 pipeline {
+  
+  parameters {
+   booleanParam(name: 'RUN_DOWNSTREAM', description: 'if false skip downstream jobs', defaultValue: true)
+   booleanParam(name: 'RUN_TESTS', description: 'if false skip testing', defaultValue: true)
+   booleanParam(name: 'RUN_BUILD', description: 'if false skip building', defaultValue: false)
+   string(name: 'jsonstr_CI_STATE', description: 'Default State if no upstream job',
+              defaultValue: '''{
+"NRFX":{"WAITING":"false", "BRANCH_NAME":"master","GIT_BRANCH":" ","GIT_URL":"https://projecttools.nordicsemi.no/bitbucket/scm/nrffosdk/nrfx.git"},
+}''')
+  }
+
   agent {
     docker {
       image "$IMAGE_TAG"
-      label "docker && build-node && ncs && linux"
+      label "$AGENT_LABELS"
       args '-e PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/workdir/.local/bin'
     }
   }
@@ -37,91 +53,129 @@ pipeline {
   }
 
   stages {
-    stage('Checkout repositories') {
+    stage('Load') {
       steps {
-        dir("ci-tools") {
-          git branch: "master", url: "$REPO_CI_TOOLS"
-          sh "git checkout ${REPO_CI_TOOLS_SHA}"
+        script {
+          CI_STATE = lib_State.load(params['jsonstr_CI_STATE'])
+          lib_State.store('ZEPHYR', CI_STATE)
+          lib_State.getParentJob(CI_STATE)
+          lib_State.pushjobStack('ZEPHYR', CI_STATE)
+          println "CI_STATE = $CI_STATE"
         }
+      }
+    }
+    stage('Checkout repositories') {
+      when { expression {  CI_STATE.ZEPHYR.RUN_TESTS || CI_STATE.ZEPHYR.RUN_BUILD } }
+      steps {
+        script {
+          lib_Main.cloneCItools(JOB_NAME)
+          CI_STATE.ZEPHYR.REPORT_SHA = lib_Main.checkoutRepo(CI_STATE.ZEPHYR.GIT_URL, "zephyr", CI_STATE, false)
+          lib_West.AddManifestUpdate("ZEPHYR", 'zephyr', CI_STATE.ZEPHYR.GIT_URL, CI_STATE.ZEPHYR.REPORT_SHA, CI_STATE)
+          lib_West.InitUpdate('zephyr')
+        }
+      }
+    }
+    stage('Apply Parent Manifest Updates') {
+      when { expression { CI_STATE.ZEPHYR.RUN_TESTS || CI_STATE.ZEPHYR.RUN_BUILD } }
+      steps {
+        script {
+          println "If triggered by an upstream Project, use their changes."
+          lib_West.ApplyManfestUpdates(CI_STATE)
+        }
+      }
+    }
+    stage('Run compliance check') {
+      when { expression { CI_STATE.ZEPHYR.RUN_TESTS } }
+      steps {
         dir('zephyr') {
-          sh "git rev-parse HEAD"
+          script {
+            def BUILD_TYPE = lib_Main.getBuildType(CI_STATE.ZEPHYR)
+            if (BUILD_TYPE == "PR") {
+              COMMIT_RANGE = "$CI_STATE.ZEPHYR.MERGE_BASE..$CI_STATE.ZEPHYR.REPORT_SHA"
+              COMPLIANCE_ARGS = "$COMPLIANCE_ARGS -p $CHANGE_ID -S $CI_STATE.ZEPHYR.REPORT_SHA -g"
+              println "Building a PR [$CHANGE_ID]: $COMMIT_RANGE"
+            }
+            else if (BUILD_TYPE == "TAG") {
+              COMMIT_RANGE = "tags/${env.BRANCH_NAME}..tags/${env.BRANCH_NAME}"
+              println "Building a Tag: " + COMMIT_RANGE
+            }
+            // If not a PR, it's a non-PR-branch or master build. Compare against the origin.
+            else if (BUILD_TYPE == "BRANCH") {
+              COMMIT_RANGE = "origin/${env.BRANCH_NAME}..HEAD"
+              println "Building a Branch: " + COMMIT_RANGE
+            }
+            else {
+                assert condition : "Build fails because it is not a PR/Tag/Branch"
+            }
+
+            // Run the compliance check
+            try {
+              sh "(source ../zephyr/zephyr-env.sh && ../ci-tools/scripts/check_compliance.py $COMPLIANCE_ARGS --commits $COMMIT_RANGE)"
+            }
+            finally {
+              junit 'compliance.xml'
+              archiveArtifacts artifacts: 'compliance.xml'
+            }
+          }
         }
-
-        // Initialize west
-        sh "west init -l zephyr/"
-
-        // Checkout
-        sh "west update"
+      }
+    }
+    stage('Sanitycheck (all)') {
+      when { expression { CI_STATE.ZEPHYR.RUN_BUILD } }
+      steps {
+        dir('zephyr') {
+          sh "echo variant: $ZEPHYR_TOOLCHAIN_VARIANT"
+          sh "echo SDK dir: $ZEPHYR_SDK_INSTALL_DIR"
+          sh "cat /opt/zephyr-sdk/sdk_version"
+          sh "source zephyr-env.sh && \
+              (./scripts/sanitycheck $SANITYCHECK_OPTIONS $ARCH || \
+              (sleep 10; ./scripts/sanitycheck $SANITYCHECK_OPTIONS $SANITYCHECK_RETRY) || \
+              (sleep 10; ./scripts/sanitycheck $SANITYCHECK_OPTIONS $SANITYCHECK_RETRY_2))"
+        }
       }
     }
 
-    stage('Testing') {
-      parallel {
-        stage('Run compliance check') {
-          steps {
-            dir('zephyr') {
-              script {
-                // If we're a pull request, compare the target branch against the current HEAD (the PR)
-                println "CHANGE_TARGET = ${env.CHANGE_TARGET}"
-                println "BRANCH_NAME = ${env.BRANCH_NAME}"
-                println "TAG_NAME = ${env.TAG_NAME}"
+    stage('Trigger testing build') {
+      when { expression { CI_STATE.ZEPHYR.RUN_DOWNSTREAM } }
+      steps {
+        script {
+          CI_STATE.ZEPHYR.WAITING = true
+          def DOWNSTREAM_JOBS = lib_Main.getDownStreamJobs(CI_STATE, 'ZEPHYR')
+          println "DOWNSTREAM_JOBS = " + DOWNSTREAM_JOBS
 
-                if (env.CHANGE_TARGET) {
-                  COMMIT_RANGE = "origin/${env.CHANGE_TARGET}..HEAD"
-                  COMPLIANCE_ARGS = "$COMPLIANCE_ARGS $COMPLIANCE_REPORT_ARGS"
-                  sh "echo change id: $CHANGE_ID"
-                  sh "echo git commit: $GIT_COMMIT"
-                  sh "echo commit range: $COMMIT_RANGE"
-                  sh "git rev-parse origin/$CHANGE_TARGET"
-                  sh "git rev-parse HEAD"
-                  println "Building a PR: ${COMMIT_RANGE}"
-                }
-                else if (env.TAG_NAME) {
-                  COMMIT_RANGE = "tags/${env.BRANCH_NAME}..tags/${env.BRANCH_NAME}"
-                  println "Building a Tag: ${COMMIT_RANGE}"
-                }
-                // If not a PR, it's a non-PR-branch or master build. Compare against the origin.
-                else if (env.BRANCH_NAME) {
-                  COMMIT_RANGE = "origin/${env.BRANCH_NAME}..HEAD"
-                  println "Building a Branch: ${COMMIT_RANGE}"
-                }
-                else {
-                    assert condition : "Build fails because it is not a PR/Tag/Branch"
-                }
-                // Run the compliance check
-                try {
-                  sh "(source zephyr-env.sh && ../ci-tools/scripts/check_compliance.py $COMPLIANCE_ARGS --commits $COMMIT_RANGE)"
-                }
-                finally {
-                  junit 'compliance.xml'
-                  archiveArtifacts artifacts: 'compliance.xml'
-                }
-              }
+          def jobs = [:]
+          DOWNSTREAM_JOBS.each {
+            jobs["${it}"] = {
+              build job: "${it}", propagate: true, wait: true, parameters: [
+                        string(name: 'jsonstr_CI_STATE', value: lib_Util.HashMap2Str(CI_STATE))]
             }
           }
-        }
-
-        stage('Sanitycheck (all)') {
-          steps {
-            dir('zephyr') {
-              sh "echo variant: $ZEPHYR_TOOLCHAIN_VARIANT"
-              sh "echo SDK dir: $ZEPHYR_SDK_INSTALL_DIR"
-              sh "cat /opt/zephyr-sdk/sdk_version"
-              sh "source zephyr-env.sh && \
-                  (./scripts/sanitycheck $SANITYCHECK_OPTIONS $ARCH || \
-                  (sleep 10; ./scripts/sanitycheck $SANITYCHECK_OPTIONS $SANITYCHECK_RETRY) || \
-                  (sleep 10; ./scripts/sanitycheck $SANITYCHECK_OPTIONS $SANITYCHECK_RETRY_2))"
-            }
-          }
+          parallel jobs
         }
       }
     }
   }
 
   post {
+    // This is the order that the methods are run. {always->success/abort/failure/unstable->cleanup}
     always {
-      // Clean up the working space at the end (including tracked files)
-      cleanWs()
+      echo "always"
+    }
+    success {
+      echo "success"
+    }
+    aborted {
+      echo "aborted"
+    }
+    unstable {
+      echo "unstable"
+    }
+    failure {
+      echo "failure"
+    }
+    cleanup {
+        echo "cleanup"
+        cleanWs()
     }
   }
 }


### PR DESCRIPTION
Managing Docker version, Agent Labels, Github Status, manifest updates, downstream jobs from CI_LIB.

More info: https://projecttools.nordicsemi.no/confluence/display/NCS/Auto-Linking+Jenkins+Jobs+Together

Signed-off-by: Thomas Stilwell Thomas.Stilwell@nordicsemi.no