### PR TITLE
[nrf noup] ci: use Standard Library in Jenkinsfile to link sub-projects together

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,18 +1,33 @@
-def IMAGE_TAG = "ncs-toolchain:1.08"
-def REPO_CI_TOOLS = "https://github.com/zephyrproject-rtos/ci-tools.git"
-def REPO_CI_TOOLS_SHA = "bfe635f102271a4ad71c1a14824f9d5e64734e57"
+
+@Library("CI_LIB") _
+
+def AGENT_LABELS = lib_Main.getAgentLabels(JOB_NAME)
+def IMAGE_TAG    = lib_Main.getDockerImage(JOB_NAME)
+def TIMEOUT      = lib_Main.getTimeout(JOB_NAME)
+def INPUT_STATE  = lib_Main.getInputState(JOB_NAME)
+def CI_STATE = new HashMap()
 
 pipeline {
+
+  parameters {
+   booleanParam(name: 'RUN_DOWNSTREAM', description: 'if false skip downstream jobs', defaultValue: true)
+   booleanParam(name: 'RUN_TESTS', description: 'if false skip testing', defaultValue: true)
+   booleanParam(name: 'RUN_BUILD', description: 'if false skip building', defaultValue: true)
+   string(name: 'jsonstr_CI_STATE', description: 'Default State if no upstream job',
+              defaultValue: INPUT_STATE)
+  }
+
   agent {
     docker {
-      image "$IMAGE_TAG"
-      label "docker && build-node && ncs && linux"
+      image IMAGE_TAG
+      label AGENT_LABELS
       args '-e PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/workdir/.local/bin'
     }
   }
   options {
     // Checkout the repository to this folder instead of root
     checkoutToSubdirectory('zephyr')
+    timeout(time: TIMEOUT.time, unit: TIMEOUT.unit)
   }
 
   environment {
@@ -20,7 +35,6 @@ pipeline {
       GH_TOKEN = credentials('nordicbuilder-compliance-token') // This token is used to by check_compliance to comment on PRs and use checks
       GH_USERNAME = "NordicBuilder"
       COMPLIANCE_ARGS = "-r NordicPlayground/fw-nrfconnect-zephyr --exclude-module Kconfig"
-      COMPLIANCE_REPORT_ARGS = "-p $CHANGE_ID -S $GIT_COMMIT -g"
 
       LC_ALL = "C.UTF-8"
 
@@ -37,91 +51,120 @@ pipeline {
   }
 
   stages {
-    stage('Checkout repositories') {
-      steps {
-        dir("ci-tools") {
-          git branch: "master", url: "$REPO_CI_TOOLS"
-          sh "git checkout ${REPO_CI_TOOLS_SHA}"
-        }
+    stage('Load') { steps { script { CI_STATE = lib_Stage.load('ZEPHYR') }}}
+    stage('Checkout') {
+      steps { script {
+        lib_Main.cloneCItools(JOB_NAME)
         dir('zephyr') {
-          sh "git rev-parse HEAD"
+          CI_STATE.ZEPHYR.REPORT_SHA = lib_Main.checkoutRepo(CI_STATE.ZEPHYR.GIT_URL, "ZEPHYR", CI_STATE.ZEPHYR, false)
+          lib_West.AddManifestUpdate("ZEPHYR", 'zephyr', CI_STATE.ZEPHYR.GIT_URL, CI_STATE.ZEPHYR.GIT_REF, CI_STATE)
         }
+      }}
+    }
+    stage('Get nRF && Apply Parent Manifest Updates') {
+      when { expression { CI_STATE.ZEPHYR.RUN_TESTS || CI_STATE.ZEPHYR.RUN_BUILD } }
+      steps { script {
+        lib_Status.set("PENDING", 'ZEPHYR', CI_STATE);
+        lib_West.InitUpdate('zephyr')
+        lib_West.ApplyManifestUpdates(CI_STATE)
+      }}
+    }
+    stage('Run compliance check') {
+      when { expression { CI_STATE.ZEPHYR.RUN_TESTS } }
+      steps {
+        dir('zephyr') {
+          script {
+            def BUILD_TYPE = lib_Main.getBuildType(CI_STATE.ZEPHYR)
+            if (BUILD_TYPE == "PR") {
+              COMMIT_RANGE = "$CI_STATE.ZEPHYR.MERGE_BASE..$CI_STATE.ZEPHYR.REPORT_SHA"
+              COMPLIANCE_ARGS = "$COMPLIANCE_ARGS -p $CHANGE_ID -S $CI_STATE.ZEPHYR.REPORT_SHA -g"
+              println "Building a PR [$CHANGE_ID]: $COMMIT_RANGE"
+            }
+            else if (BUILD_TYPE == "TAG") {
+              COMMIT_RANGE = "tags/${env.BRANCH_NAME}..tags/${env.BRANCH_NAME}"
+              println "Building a Tag: " + COMMIT_RANGE
+            }
+            // If not a PR, it's a non-PR-branch or master build. Compare against the origin.
+            else if (BUILD_TYPE == "BRANCH") {
+              COMMIT_RANGE = "origin/${env.BRANCH_NAME}..HEAD"
+              println "Building a Branch: " + COMMIT_RANGE
+            }
+            else {
+                assert condition : "Build fails because it is not a PR/Tag/Branch"
+            }
 
-        // Initialize west
-        sh "west init -l zephyr/"
-
-        // Checkout
-        sh "west update"
+            // Run the compliance check
+            try {
+              sh "(source ../zephyr/zephyr-env.sh && ../ci-tools/scripts/check_compliance.py $COMPLIANCE_ARGS --commits $COMMIT_RANGE)"
+            }
+            finally {
+              junit 'compliance.xml'
+              archiveArtifacts artifacts: 'compliance.xml'
+            }
+          }
+        }
+      }
+    }
+    stage('Sanitycheck (all)') {
+      when { expression { CI_STATE.ZEPHYR.RUN_BUILD } }
+      steps {
+        dir('zephyr') {
+          sh "ls -alh "
+          sh "echo variant: $ZEPHYR_TOOLCHAIN_VARIANT"
+          sh "echo SDK dir: $ZEPHYR_SDK_INSTALL_DIR"
+          sh "cat /opt/zephyr-sdk/sdk_version"
+          sh "source zephyr-env.sh && \
+              (./scripts/sanitycheck $SANITYCHECK_OPTIONS $ARCH || \
+              (sleep 10; ./scripts/sanitycheck $SANITYCHECK_OPTIONS $SANITYCHECK_RETRY) || \
+              (sleep 10; ./scripts/sanitycheck $SANITYCHECK_OPTIONS $SANITYCHECK_RETRY_2))"
+        }
       }
     }
 
-    stage('Testing') {
-      parallel {
-        stage('Run compliance check') {
-          steps {
-            dir('zephyr') {
-              script {
-                // If we're a pull request, compare the target branch against the current HEAD (the PR)
-                println "CHANGE_TARGET = ${env.CHANGE_TARGET}"
-                println "BRANCH_NAME = ${env.BRANCH_NAME}"
-                println "TAG_NAME = ${env.TAG_NAME}"
+    stage('Trigger testing build') {
+      when { expression { CI_STATE.ZEPHYR.RUN_DOWNSTREAM } }
+      steps {
+        script {
+          CI_STATE.ZEPHYR.WAITING = true
+          def DOWNSTREAM_JOBS = lib_Main.getDownStreamJobs(JOB_NAME)
+          println "DOWNSTREAM_JOBS = " + DOWNSTREAM_JOBS
 
-                if (env.CHANGE_TARGET) {
-                  COMMIT_RANGE = "origin/${env.CHANGE_TARGET}..HEAD"
-                  COMPLIANCE_ARGS = "$COMPLIANCE_ARGS $COMPLIANCE_REPORT_ARGS"
-                  sh "echo change id: $CHANGE_ID"
-                  sh "echo git commit: $GIT_COMMIT"
-                  sh "echo commit range: $COMMIT_RANGE"
-                  sh "git rev-parse origin/$CHANGE_TARGET"
-                  sh "git rev-parse HEAD"
-                  println "Building a PR: ${COMMIT_RANGE}"
-                }
-                else if (env.TAG_NAME) {
-                  COMMIT_RANGE = "tags/${env.BRANCH_NAME}..tags/${env.BRANCH_NAME}"
-                  println "Building a Tag: ${COMMIT_RANGE}"
-                }
-                // If not a PR, it's a non-PR-branch or master build. Compare against the origin.
-                else if (env.BRANCH_NAME) {
-                  COMMIT_RANGE = "origin/${env.BRANCH_NAME}..HEAD"
-                  println "Building a Branch: ${COMMIT_RANGE}"
-                }
-                else {
-                    assert condition : "Build fails because it is not a PR/Tag/Branch"
-                }
-                // Run the compliance check
-                try {
-                  sh "(source zephyr-env.sh && ../ci-tools/scripts/check_compliance.py $COMPLIANCE_ARGS --commits $COMMIT_RANGE)"
-                }
-                finally {
-                  junit 'compliance.xml'
-                  archiveArtifacts artifacts: 'compliance.xml'
-                }
-              }
+          def jobs = [:]
+          DOWNSTREAM_JOBS.each {
+            jobs["${it}"] = {
+              build job: "${it}", propagate: true, wait: CI_STATE.ZEPHYR.WAITING, parameters: [
+                        string(name: 'jsonstr_CI_STATE', value: lib_Util.HashMap2Str(CI_STATE))]
             }
           }
-        }
-
-        stage('Sanitycheck (all)') {
-          steps {
-            dir('zephyr') {
-              sh "echo variant: $ZEPHYR_TOOLCHAIN_VARIANT"
-              sh "echo SDK dir: $ZEPHYR_SDK_INSTALL_DIR"
-              sh "cat /opt/zephyr-sdk/sdk_version"
-              sh "source zephyr-env.sh && \
-                  (./scripts/sanitycheck $SANITYCHECK_OPTIONS $ARCH || \
-                  (sleep 10; ./scripts/sanitycheck $SANITYCHECK_OPTIONS $SANITYCHECK_RETRY) || \
-                  (sleep 10; ./scripts/sanitycheck $SANITYCHECK_OPTIONS $SANITYCHECK_RETRY_2))"
-            }
-          }
+          parallel jobs
         }
       }
     }
   }
 
   post {
+    // This is the order that the methods are run. {always->success/abort/failure/unstable->cleanup}
     always {
-      // Clean up the working space at the end (including tracked files)
-      cleanWs()
+      echo "always"
+    }
+    success {
+      echo "success"
+      script { lib_Status.set("SUCCESS", 'ZEPHYR', CI_STATE) }
+    }
+    aborted {
+      echo "aborted"
+      script { lib_Status.set("ABORTED", 'ZEPHYR', CI_STATE) }
+    }
+    unstable {
+      echo "unstable"
+    }
+    failure {
+      echo "failure"
+      script { lib_Status.set("FAILURE", 'ZEPHYR', CI_STATE) }
+    }
+    cleanup {
+        echo "cleanup"
+        cleanWs()
     }
   }
 }


### PR DESCRIPTION
Managing Docker version, Agent Labels, Github Status,
manifest updates, downstream jobs from CI_LIB.

More info: https://projecttools.nordicsemi.no/confluence/display/NCS/Linking+Jenkins+Jobs+Together

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>