### PR TITLE
Multi image fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,9 @@ zephyr_cc_option(-fmacro-prefix-map=${ZEPHYR_BASE}=ZEPHYR_BASE)
 
 # Declare MPU userspace dependencies before the linker scripts to make
 # sure the order of dependencies are met
+unset(APP_SMEM_ALIGNED_DEP)
+unset(APP_SMEM_UNALIGNED_DEP)
+unset(PRIV_STACK_DEP)
 if(CONFIG_USERSPACE)
   set(APP_SMEM_ALIGNED_DEP ${IMAGE}app_smem_aligned_linker)
   set(APP_SMEM_UNALIGNED_DEP ${IMAGE}app_smem_unaligned_linker)
@@ -660,6 +663,7 @@ endforeach()
 
 get_property(OUTPUT_FORMAT        GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)
 
+unset(CODE_RELOCATION_DEP)
 if (CONFIG_CODE_DATA_RELOCATION)
   set(CODE_RELOCATION_DEP ${IMAGE}code_relocation_source_lib)
 endif() # CONFIG_CODE_DATA_RELOCATION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,8 +355,8 @@ zephyr_cc_option(-fmacro-prefix-map=${ZEPHYR_BASE}=ZEPHYR_BASE)
 # Declare MPU userspace dependencies before the linker scripts to make
 # sure the order of dependencies are met
 if(CONFIG_USERSPACE)
-  set(APP_SMEM_ALIGNED_DEP app_smem_aligned_linker)
-  set(APP_SMEM_UNALIGNED_DEP app_smem_unaligned_linker)
+  set(APP_SMEM_ALIGNED_DEP ${IMAGE}app_smem_aligned_linker)
+  set(APP_SMEM_UNALIGNED_DEP ${IMAGE}app_smem_unaligned_linker)
   if(CONFIG_ARM)
     set(PRIV_STACK_DEP ${PRIV_STACKS_PREBUILT})
   endif()
@@ -661,7 +661,7 @@ endforeach()
 get_property(OUTPUT_FORMAT        GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)
 
 if (CONFIG_CODE_DATA_RELOCATION)
-  set(CODE_RELOCATION_DEP code_relocation_source_lib)
+  set(CODE_RELOCATION_DEP ${IMAGE}code_relocation_source_lib)
 endif() # CONFIG_CODE_DATA_RELOCATION
 
 configure_linker_script(


### PR DESCRIPTION
Misc. multi-image related build fixes:

Add an IMAGE prefix to new targets that have been introduced and ensure that variables are initialized before de-referenced.

This fixes the build issues with nrf91ns+userspace.