### PR TITLE
[nrf noup] net: lwm2m: add timestamp fields to several IPSO obj

### DIFF
--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -114,7 +114,8 @@ static int flash_progressive_erase(struct flash_img_context *ctx, off_t off)
 	} else {
 		if (ctx->off_last != sector.fs_off) {
 			ctx->off_last = sector.fs_off;
-			LOG_INF("Erasing sector at offset 0x%x", sector.fs_off);
+			LOG_INF("Erasing sector at offset 0x%x",
+				(u32_t)sector.fs_off);
 			rc = flash_area_erase(ctx->flash_area, sector.fs_off,
 					      sector.fs_size);
 			if (rc) {

--- a/subsys/net/lib/lwm2m/ipso_accelerometer.c
+++ b/subsys/net/lib/lwm2m/ipso_accelerometer.c
@@ -28,8 +28,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define ACCEL_SENSOR_UNITS_ID			5701
 #define ACCEL_MIN_RANGE_VALUE_ID		5603
 #define ACCEL_MAX_RANGE_VALUE_ID		5604
+/* This field is not in spec but can be used to record event time */
+#define ACCEL_TIMESTAMP_ID			5518
 
-#define ACCEL_MAX_ID		6
+#define ACCEL_MAX_ID		7
 
 #define MAX_INSTANCE_COUNT	CONFIG_LWM2M_IPSO_ACCELEROMETER_INSTANCE_COUNT
 
@@ -58,6 +60,7 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(ACCEL_SENSOR_UNITS_ID, R_OPT, STRING),
 	OBJ_FIELD_DATA(ACCEL_MIN_RANGE_VALUE_ID, R_OPT, FLOAT32),
 	OBJ_FIELD_DATA(ACCEL_MAX_RANGE_VALUE_ID, R_OPT, FLOAT32),
+	OBJ_FIELD_DATA(ACCEL_TIMESTAMP_ID, RW_OPT, TIME),
 };
 
 static struct lwm2m_engine_obj_inst inst[MAX_INSTANCE_COUNT];
@@ -116,6 +119,8 @@ static struct lwm2m_engine_obj_inst *accel_create(u16_t obj_inst_id)
 			  res_inst[avail], j,
 			  &accel_data[avail].max_range,
 			  sizeof(accel_data[avail].max_range));
+	INIT_OBJ_RES_OPTDATA(ACCEL_TIMESTAMP_ID, res[avail], i,
+			     res_inst[avail], j);
 
 	inst[avail].resources = res[avail];
 	inst[avail].resource_count = i;

--- a/subsys/net/lib/lwm2m/ipso_onoff_switch.c
+++ b/subsys/net/lib/lwm2m/ipso_onoff_switch.c
@@ -27,8 +27,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define SWITCH_ON_TIME_ID		5852
 #define SWITCH_OFF_TIME_ID		5854
 #define SWITCH_APPLICATION_TYPE_ID	5750
+/* This field is not in spec but can be used to record switch event time */
+#define SWITCH_TIMESTAMP_ID		5518
 
-#define SWITCH_MAX_ID			5
+#define SWITCH_MAX_ID			6
 
 #define MAX_INSTANCE_COUNT	CONFIG_LWM2M_IPSO_ONOFF_SWITCH_INSTANCE_COUNT
 
@@ -58,6 +60,7 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(SWITCH_ON_TIME_ID, RW_OPT, U64),
 	OBJ_FIELD_DATA(SWITCH_OFF_TIME_ID, RW_OPT, U64),
 	OBJ_FIELD_DATA(SWITCH_APPLICATION_TYPE_ID, RW_OPT, STRING),
+	OBJ_FIELD_DATA(SWITCH_TIMESTAMP_ID, RW_OPT, TIME),
 };
 
 static struct lwm2m_engine_obj_inst inst[MAX_INSTANCE_COUNT];
@@ -212,6 +215,8 @@ static struct lwm2m_engine_obj_inst *switch_create(u16_t obj_inst_id)
 		     res_inst[avail], j, 1, true,
 		     off_time_read_cb, NULL, time_post_write_cb, NULL);
 	INIT_OBJ_RES_OPTDATA(SWITCH_APPLICATION_TYPE_ID, res[avail], i,
+			     res_inst[avail], j);
+	INIT_OBJ_RES_OPTDATA(SWITCH_TIMESTAMP_ID, res[avail], i,
 			     res_inst[avail], j);
 
 	inst[avail].resources = res[avail];

--- a/subsys/net/lib/lwm2m/ipso_push_button.c
+++ b/subsys/net/lib/lwm2m/ipso_push_button.c
@@ -25,8 +25,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define BUTTON_DIGITAL_STATE_ID		5500
 #define BUTTON_DIGITAL_INPUT_COUNTER_ID	5501
 #define BUTTON_APPLICATION_TYPE_ID	5750
+/* This field is not in spec but can be used to record button event time */
+#define BUTTON_TIMESTAMP_ID		5518
 
-#define BUTTON_MAX_ID			3
+#define BUTTON_MAX_ID			4
 
 #define MAX_INSTANCE_COUNT	CONFIG_LWM2M_IPSO_PUSH_BUTTON_INSTANCE_COUNT
 
@@ -51,6 +53,7 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(BUTTON_DIGITAL_STATE_ID, R, BOOL),
 	OBJ_FIELD_DATA(BUTTON_DIGITAL_INPUT_COUNTER_ID, R_OPT, U64),
 	OBJ_FIELD_DATA(BUTTON_APPLICATION_TYPE_ID, RW_OPT, STRING),
+	OBJ_FIELD_DATA(BUTTON_TIMESTAMP_ID, RW_OPT, TIME),
 };
 
 static struct lwm2m_engine_obj_inst inst[MAX_INSTANCE_COUNT];
@@ -138,6 +141,8 @@ static struct lwm2m_engine_obj_inst *button_create(u16_t obj_inst_id)
 			  &button_data[avail].counter,
 			  sizeof(button_data[avail].counter));
 	INIT_OBJ_RES_OPTDATA(BUTTON_APPLICATION_TYPE_ID, res[avail], i,
+			     res_inst[avail], j);
+	INIT_OBJ_RES_OPTDATA(BUTTON_TIMESTAMP_ID, res[avail], i,
 			     res_inst[avail], j);
 
 	inst[avail].resources = res[avail];

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -31,8 +31,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define TEMP_MIN_RANGE_VALUE_ID			5603
 #define TEMP_MAX_RANGE_VALUE_ID			5604
 #define TEMP_RESET_MIN_MAX_MEASURED_VALUES_ID	5605
+/* This field is not in spec but can be used to record temp recording time */
+#define TEMP_TIMESTAMP_ID			5518
 
-#define TEMP_MAX_ID		7
+#define TEMP_MAX_ID		8
 
 #define MAX_INSTANCE_COUNT	CONFIG_LWM2M_IPSO_TEMP_SENSOR_INSTANCE_COUNT
 
@@ -62,6 +64,7 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(TEMP_MIN_RANGE_VALUE_ID, R_OPT, FLOAT32),
 	OBJ_FIELD_DATA(TEMP_MAX_RANGE_VALUE_ID, R_OPT, FLOAT32),
 	OBJ_FIELD_EXECUTE_OPT(TEMP_RESET_MIN_MAX_MEASURED_VALUES_ID),
+	OBJ_FIELD_DATA(TEMP_TIMESTAMP_ID, RW_OPT, TIME),
 };
 
 static struct lwm2m_engine_obj_inst inst[MAX_INSTANCE_COUNT];
@@ -207,6 +210,8 @@ static struct lwm2m_engine_obj_inst *temp_sensor_create(u16_t obj_inst_id)
 			  sizeof(*max_range_value));
 	INIT_OBJ_RES_EXECUTE(TEMP_RESET_MIN_MAX_MEASURED_VALUES_ID,
 			     res[index], i, reset_min_max_measured_values_cb);
+	INIT_OBJ_RES_OPTDATA(TEMP_TIMESTAMP_ID, res[index], i,
+			     res_inst[index], j);
 
 	inst[index].resources = res[index];
 	inst[index].resource_count = i;


### PR DESCRIPTION
Let's add a timestamp field to the following objects for better
event tracking:
- IPSO Accelerometer
- IPSO On/Off switch
- IPSO Push Button
- IPSO Temperature

Signed-off-by: Michael Scott <mike@foundries.io>