### PR TITLE
[nrf toup] subsys: dfu: img_util: fix warning in flash_img.c

### DIFF
--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -114,7 +114,8 @@ static int flash_progressive_erase(struct flash_img_context *ctx, off_t off)
 	} else {
 		if (ctx->off_last != sector.fs_off) {
 			ctx->off_last = sector.fs_off;
-			LOG_INF("Erasing sector at offset 0x%x", sector.fs_off);
+			LOG_INF("Erasing sector at offset 0x%x",
+				(u32_t)sector.fs_off);
 			rc = flash_area_erase(ctx->flash_area, sector.fs_off,
 					      sector.fs_size);
 			if (rc) {


### PR DESCRIPTION
CI revealed a warning (treated as an error) in flash_img.c:
subsys/dfu/img_util/flash_img.c:117:12: error: format '%x' expects
  argument of type 'unsigned int', but argument 2 has type 'off_t
  {aka long int}' [-Werror=format=]
    LOG_INF("Erasing sector at offset 0x%x", sector.fs_off);
            ^                                ~~~~~~~~

Let's fix CI by casting sector.fs_off to u32_t.

Signed-off-by: Michael Scott <mike@foundries.io>