### PR TITLE
[nrf fromtree] requirements.txt: change package name "hub" to "git-sp…

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -7,7 +7,7 @@ sphinxcontrib-svg2pdfconverter
 junit2html
 PyYAML>=3.13
 ply==3.10
-hub==2.0
+git-spindle==2.0
 gitlint
 pyelftools==0.24
 pyocd==0.21.0


### PR DESCRIPTION
…indle"

Package "hub" has been renamed some time ago to "git-spindle".
Recently package with the same name "hub" has been released on PyPi
page, which causes installing pip requirements.txt to fail since
it is trying to install different package.

Signed-off-by: Marcin Sloniewski <marcin.sloniewski@gmail.com>
Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>