### PR TITLE
[nrf-noup] cmake: remove check for including 'drivers'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,7 @@ endif()
 add_subdirectory(boards)
 add_subdirectory(ext)
 add_subdirectory(subsys)
-add_subdirectory_ifdef(CONFIG_KERNEL drivers)
+add_subdirectory(drivers)
 
 # Include zephyr modules generated CMake file.
 if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)


### PR DESCRIPTION
Previously the build code in the 'drivers' folder included
some files which caused a compilation error for B0.

This problem has been fixed, and the folder can now
safely be included in the build.

This aligns with upstream code.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>