### PR TITLE
[nrf toup] drivers/flash: leverage nsc flash read

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -16,6 +16,11 @@
 #include <string.h>
 #include <nrfx_nvmc.h>
 
+#if CONFIG_ARM_NONSECURE_FIRMWARE
+#include <secure_services.h>
+#include <pm_config.h>
+#endif
+
 #if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC)
 #include <sys/__assert.h>
 #include <bluetooth/hci.h>
@@ -141,6 +146,12 @@ static int flash_nrf_read(struct device *dev, off_t addr,
 	if (!len) {
 		return 0;
 	}
+
+#if CONFIG_ARM_NONSECURE_FIRMWARE
+	if (addr < PM_APP_ADDRESS) {
+		return spm_request_read(data, addr, len);
+	}
+#endif
 
 	memcpy(data, (void *)addr, len);
 


### PR DESCRIPTION
When current image is non-secure and address being read is configured
as secure, use the Non Secure Callable function spm_request_read to
try and read the secure flash area.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>