### PR TITLE
Build s1 variant of mcuboot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1252,6 +1252,69 @@ set(logical_target_for_zephyr_elf ${logical_target_for_zephyr_elf} PARENT_SCOPE)
 # 2. it can be defined in Kconfig
 set_target_properties(${logical_target_for_zephyr_elf} PROPERTIES OUTPUT_NAME ${KERNEL_NAME})
 
+if (IMAGE STREQUAL mcuboot_ AND CONFIG_MCUBOOT_BUILD_S1_VARIANT)
+# Create second MCUBoot executable for the second slot of the second stage
+# bootloader. This is done inside this file since it is non-trivial to add
+# executable targets outside the root CMakeLists.txt. The problem is that
+# most of the variables requried for compiling/linking is only available
+# in the scope of this file.
+
+  # Create linker script which has an offset from S0 to S1.
+  configure_linker_script(
+    ${PROJECT_BINARY_DIR}/linker_mcuboot_s1.cmd
+    "-DPM_ADDRESS_LOAD_OFFSET=($<TARGET_PROPERTY:partition_manager,PM_S1_PAD_SIZE>+$<TARGET_PROPERTY:partition_manager,PM_S0_SIZE>);-DLINKER_PASS2"
+    ${PRIV_STACK_DEP}
+    ${CODE_RELOCATION_DEP}
+    ${ZEPHYR_PREBUILT_EXECUTABLE}
+    ${OFFSETS_H_TARGET}
+    ${mcuboot_logical_target} # See partition_manager.cmake
+    )
+
+  add_custom_target(
+    linker_mcuboot_s1_target
+    DEPENDS
+    linker_mcuboot_s1.cmd
+    )
+
+  # Link against linker script with updated offset.
+  set(MCUBOOT_S1_EXECUTABLE s1_image)
+  add_executable(${MCUBOOT_S1_EXECUTABLE} ${ZEPHYR_BASE}/misc/empty_file.c)
+  toolchain_ld_link_elf(
+    TARGET_ELF            ${MCUBOOT_S1_EXECUTABLE}
+    OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${MCUBOOT_S1_EXECUTABLE}.map
+    LIBRARIES_PRE_SCRIPT  ""
+    LINKER_SCRIPT         ${PROJECT_BINARY_DIR}/linker_mcuboot_s1.cmd
+    LIBRARIES_POST_SCRIPT ""
+    DEPENDENCIES          ""
+    )
+  add_dependencies(${MCUBOOT_S1_EXECUTABLE} linker_mcuboot_s1_target)
+
+  set(s1_hex_cmd "")
+  set(s1_hex_byprod "")
+
+  # Rule to generate hex file of .elf
+  bintools_objcopy(
+    RESULT_CMD_LIST    s1_hex_cmd
+    RESULT_BYPROD_LIST s1_hex_byprod
+    STRIP_ALL
+    GAP_FILL           "0xff"
+    TARGET_OUTPUT      "ihex"
+    SECTION_REMOVE     ${out_hex_sections_remove}
+    FILE_INPUT         ${MCUBOOT_S1_EXECUTABLE}.elf
+    FILE_OUTPUT        ${PROJECT_BINARY_DIR}/../../zephyr/${MCUBOOT_S1_EXECUTABLE}.hex
+    )
+
+  add_custom_command(${s1_hex_cmd}
+    DEPENDS ${MCUBOOT_S1_EXECUTABLE}
+    OUTPUT ${MCUBOOT_S1_EXECUTABLE}.hex)
+
+  add_custom_target(
+    s1_image_hex
+    DEPENDS
+    ${MCUBOOT_S1_EXECUTABLE}.hex
+    )
+endif()
+
 set(post_build_commands "")
 set(post_build_byproducts "")
 

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -42,7 +42,11 @@
 
 #if USE_PARTITION_MANAGER
 #include <pm_config.h>
+#ifdef PM_ADDRESS_LOAD_OFFSET
+#define ROM_ADDR PM_ADDRESS + PM_ADDRESS_LOAD_OFFSET
+#else
 #define ROM_ADDR PM_ADDRESS
+#endif
 #define ROM_SIZE PM_SIZE
 #else
 


### PR DESCRIPTION
To support upgrade of mcuboot we need to build a candidate of mcuboot which is linked against the partition "s1".