### PR TITLE
cmake: use size of s0_image when offsetting mcuboot for s1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1262,7 +1262,7 @@ if (IMAGE STREQUAL mcuboot_ AND CONFIG_MCUBOOT_BUILD_S1_VARIANT)
   # Create linker script which has an offset from S0 to S1.
   configure_linker_script(
     ${PROJECT_BINARY_DIR}/linker_mcuboot_s1.cmd
-    "-DPM_ADDRESS_LOAD_OFFSET=($<TARGET_PROPERTY:partition_manager,PM_S1_PAD_SIZE>+$<TARGET_PROPERTY:partition_manager,PM_S0_SIZE>);-DLINKER_PASS2"
+    "-DPM_ADDRESS_LOAD_OFFSET=($<TARGET_PROPERTY:partition_manager,PM_S1_PAD_SIZE>+$<TARGET_PROPERTY:partition_manager,PM_S0_IMAGE_SIZE>);-DLINKER_PASS2"
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
     ${ZEPHYR_PREBUILT_EXECUTABLE}


### PR DESCRIPTION
The size of partition 's0' includes the pad, which should not be
included when calculating the offset from partition 's0_image'
(which mcuboot is linked against originally) to 's1_image'.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>