### PR TITLE
[nrf toup] drivers/flash: limit secure read inclusion

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -16,10 +16,12 @@
 #include <string.h>
 #include <nrfx_nvmc.h>
 
-#if CONFIG_ARM_NONSECURE_FIRMWARE
+#if CONFIG_ARM_NONSECURE_FIRMWARE && CONFIG_SPM
 #include <secure_services.h>
+#if USE_PARTITION_MANAGER
 #include <pm_config.h>
-#endif
+#endif /* USE_PARTITION_MANAGER */
+#endif /* CONFIG_ARM_NONSECURE_FIRMWARE  && CONFIG_SPM */
 
 #if defined(CONFIG_SOC_FLASH_NRF_RADIO_SYNC)
 #include <sys/__assert.h>
@@ -147,7 +149,7 @@ static int flash_nrf_read(struct device *dev, off_t addr,
 		return 0;
 	}
 
-#if CONFIG_ARM_NONSECURE_FIRMWARE
+#if CONFIG_ARM_NONSECURE_FIRMWARE && CONFIG_SPM && USE_PARTITION_MANAGER
 	if (addr < PM_APP_ADDRESS) {
 		return spm_request_read(data, addr, len);
 	}


### PR DESCRIPTION
Only include secure read call if SPM is enabled and partition manager is
in use.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>