### PR TITLE
[nrf noup]: include: net: Add option for PDN sockets.

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -789,6 +789,7 @@ struct ifreq {
 
 /* Socket options for SOL_PDN level */
 #define SO_PDN_AF 1
+#define SO_PDN_CONTEXT_ID 2
 
 /* Protocol level for DFU. */
 #define SOL_DFU 515


### PR DESCRIPTION
Adding SO_PDN_CONTEXT_ID option value for PDN sockets.

Signed-off-by: Christopher Métrailler <christopher.metrailler@nordicsemi.no>