### PR TITLE
Revert "[nrf temphack] cmake: kconfig: Support building without kernel"

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -50,10 +50,6 @@ menu "Build and Link Features"
 
 menu "Linker Options"
 
-config KERNEL
-	bool "Include Zephyr kernel"
-	default y
-
 choice
 	prompt "Linker Orphan Section Handling"
 	default LINKER_ORPHAN_SECTION_WARN

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -3,4 +3,4 @@
 add_definitions(-D__ZEPHYR_SUPERVISOR__)
 
 add_subdirectory(common)
-add_subdirectory_ifdef(CONFIG_KERNEL ${ARCH_DIR}/${ARCH} arch/${ARCH})
+add_subdirectory(${ARCH_DIR}/${ARCH} arch/${ARCH})


### PR DESCRIPTION
This reverts commit 5bbd740cf32a21fe61e3f0a9ec42299ad3083615.

This is no longer needed by b0.