### PR TITLE
[nrf noup] cmake: adjust offset after introducing alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1262,7 +1262,7 @@ if (IMAGE STREQUAL mcuboot_ AND CONFIG_MCUBOOT_BUILD_S1_VARIANT)
   # Create linker script which has an offset from S0 to S1.
   configure_linker_script(
     ${PROJECT_BINARY_DIR}/linker_mcuboot_s1.cmd
-    "-DPM_ADDRESS_LOAD_OFFSET=($<TARGET_PROPERTY:partition_manager,PM_S1_PAD_SIZE>+$<TARGET_PROPERTY:partition_manager,PM_S0_IMAGE_SIZE>);-DLINKER_PASS2"
+    "-DPM_ADDRESS_LOAD_OFFSET=($<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>-$<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>);-DLINKER_PASS2"
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
     ${ZEPHYR_PREBUILT_EXECUTABLE}


### PR DESCRIPTION
Calculate the offset needed for S1-linked mcuboot based on address
of S1 and S0. This change is needed since empty partitions
can be injected between any partition when alignment is used.
If an empty partition was inserted between S0 and S1 the old way
of calculating the offset would be incorrect.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>