### PR TITLE
[nrf noup] linker: add symbol for image 1 primary slot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1261,7 +1261,7 @@ if (IMAGE STREQUAL mcuboot_ AND CONFIG_MCUBOOT_BUILD_S1_VARIANT)
 
   # Create linker script which has an offset from S0 to S1.
   configure_linker_script(
-    ${PROJECT_BINARY_DIR}/linker_mcuboot_s1.cmd
+    linker_mcuboot_s1.cmd
     "-DPM_ADDRESS_LOAD_OFFSET=($<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>-$<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>);-DLINKER_PASS2"
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -43,10 +43,18 @@
 #if USE_PARTITION_MANAGER
 #include <pm_config.h>
 #ifdef PM_ADDRESS_LOAD_OFFSET
+/* We are linking mcuboot against S1, S0 is Image 1 primary */
+_image_1_primary_slot_id = PM_S0_ID;
+
 #define ROM_ADDR PM_ADDRESS + PM_ADDRESS_LOAD_OFFSET
 #else
+#ifdef PM_S1_ID
+/* We are linking mcuboot against S0, S1 is Image 1 primary */
+_image_1_primary_slot_id = PM_S1_ID;
+#endif /* PM_S1_ID */
+
 #define ROM_ADDR PM_ADDRESS
-#endif
+#endif /* PM_ADDRESS_LOAD_OFFSET */
 #define ROM_SIZE PM_SIZE
 #else
 


### PR DESCRIPTION
This symbol is used to ensure that s0 mcuboot points to s1 as
image 1 primary slot, and s1 mcuboot points to s0 as image 1
primary slot.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>