### PR TITLE
Add cmake boilerplate patch for Actinius Icarus IoT Dev Board

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -276,6 +276,11 @@ else() # NOT FIRST_BOILERPLATE_EXECUTION
     message("Changed board to secure nrf9160_pca20035 (NOT NS)")
   endif()
 
+  if(${BOARD} STREQUAL actinius_icarus_ns)
+    set(BOARD actinius_icarus)
+    message("Changed board to secure actinius_icarus (NOT NS)")
+  endif()
+
   unset(${IMAGE}DTC_OVERLAY_FILE)
   if(EXISTS              ${APPLICATION_SOURCE_DIR}/${BOARD}.overlay)
     set(${IMAGE}DTC_OVERLAY_FILE ${APPLICATION_SOURCE_DIR}/${BOARD}.overlay)


### PR DESCRIPTION
As the board was merged in the upstream earlier today (commit 62cb2a96abb70b2d805c93836c697d1460a2af30) I am submitting this PR to patch the boilerplate, for your consideration once the mergeup is done. Thank you.
