### PR TITLE
[nrf noup] net: socket: add SO_PDN_STATE socket option

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -795,6 +795,7 @@ struct ifreq {
 /* Socket options for SOL_PDN level */
 #define SO_PDN_AF 1
 #define SO_PDN_CONTEXT_ID 2
+#define SO_PDN_STATE 3
 
 /* Protocol level for DFU. */
 #define SOL_DFU 515


### PR DESCRIPTION
Add SO_PDN_STATE option for PDN sockets
to retrieve the state of the PDN connection.

Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>