### PR TITLE
[nrf noup] net: socket: add SO_DFU_ERROR socket option

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -807,6 +807,7 @@ struct ifreq {
 #define SO_DFU_REVERT 5
 #define SO_DFU_BACKUP_DELETE 6
 #define SO_DFU_OFFSET 7
+#define SO_DFU_ERROR 20
 
 /** @cond INTERNAL_HIDDEN */
 /**


### PR DESCRIPTION
Add SO_DFU_ERROR socket option for DFU socket.
The option can be used when a operation on a DFU socket
returns -ENOEXEC, indicating that the modem has rejected
the operation, to retrieve the reason for the error.

Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>