### PR TITLE
[nrf noup] net: socket: fix SO_DFU_RESOURCES definition

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -802,7 +802,7 @@ struct ifreq {
 
 /* Socket options for SOL_DFU level */
 #define SO_DFU_FW_VERSION 1
-#define SO_DFU_RESOURCE 2
+#define SO_DFU_RESOURCES 2
 #define SO_DFU_TIMEO 3
 #define SO_DFU_APPLY 4
 #define SO_DFU_REVERT 5


### PR DESCRIPTION
Change from `SO_DFU_RESOURCE` to `SO_DFU_RESOURCES`, as intended.
