### PR TITLE
[nrf noup] doc: Share Kconfig documentation between repos

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -220,6 +220,14 @@ set(SPHINX_BUILD_HTML_COMMAND
   ${CMAKE_COMMAND} -E env
   ZEPHYR_BASE=${ZEPHYR_BASE}
   ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
+
+  # nRF-specific hack to pass these through to nrf/doc/zephyr/conf.py (the
+  # Sphinx configuration file). We use it for Intersphinx. See
+  # nrf/doc/CMakeLists.txt.
+  ZEPHYR_OUTPUT=${SPHINX_OUTPUT_DIR}
+  ZEPHYR_RST_SRC=${RST_OUT}/doc
+  KCONFIG_OUTPUT=${KCONFIG_OUTPUT}
+
   ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_HTML})
 
 # The sphinx-html target is provided as a convenience for incremental
@@ -324,7 +332,10 @@ endif()
 #
 # Dependencies and final targets
 #
-add_dependencies(html content doxy_real_modified_times kconfig)
+
+# nRF-specific: No 'kconfig' dependency here, because we use a shared Kconfig
+# documentation set instead
+add_dependencies(html content doxy_real_modified_times)
 
 add_custom_target(
   htmldocs

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -3,11 +3,13 @@
 API Reference
 #############
 
+.. nRF-specific: There's a shared Kconfig documentation set, so
+   no kconfig/index.rst below
+
 .. toctree::
    :maxdepth: 1
 
    bluetooth/index.rst
-   kconfig/index.rst
    drivers/index.rst
    display/index.rst
    file_system/index.rst


### PR DESCRIPTION
Depends on
NordicPlayground/fw-nrfconnect-nrf#1258.

The Kconfig reference is being turned into a separate shared
documentation set, which needs three nRF-specific Zephyr tweaks:

 1. Do not build the Kconfig docs as part of the Zephyr documentation

 2. Do not link the index page of the Kconfig docs in the Zephyr
    documentation

 3. Pass some extra variables with output paths through to sphinx-build,
    so that they can be referenced in nrf/doc/zephyr/conf.py. They're
    used for the Intersphinx linking.