### PR TITLE
[nrf fromlist] samples: echo client echo server PSK support

### DIFF
--- a/samples/net/sockets/echo_client/CMakeLists.txt
+++ b/samples/net/sockets/echo_client/CMakeLists.txt
@@ -5,6 +5,18 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(sockets_echo_client)
 
+if(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED AND
+    (CONFIG_NET_SAMPLE_PSK_HEADER_FILE STREQUAL "dummy_psk.h"))
+  add_custom_target(development_psk
+    COMMAND ${CMAKE_COMMAND} -E echo "----------------------------------------------------------"
+    COMMAND ${CMAKE_COMMAND} -E echo "--- WARNING: Using dummy PSK! Only suitable for        ---"
+    COMMAND ${CMAKE_COMMAND} -E echo "--- development. Set NET_SAMPLE_PSK_HEADER_FILE to use ---"
+    COMMAND ${CMAKE_COMMAND} -E echo "--- own pre-shared key.                                ---"
+    COMMAND ${CMAKE_COMMAND} -E echo "----------------------------------------------------------"
+  )
+  add_dependencies(app development_psk)
+endif()
+
 target_sources(                     app PRIVATE src/echo-client.c)
 target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)
 target_sources_ifdef(CONFIG_NET_TCP app PRIVATE src/tcp.c)

--- a/samples/net/sockets/echo_client/Kconfig
+++ b/samples/net/sockets/echo_client/Kconfig
@@ -46,4 +46,12 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 	  Set VLAN (virtual LAN) tag (id) that is used in the sample
 	  application.
 
+config NET_SAMPLE_PSK_HEADER_FILE
+	string "Header file containing PSK"
+	default "dummy_psk.h"
+	depends on MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+	help
+	  Name of a header file containing a
+	  pre-shared key.
+
 source "Kconfig.zephyr"

--- a/samples/net/sockets/echo_client/src/ca_certificate.h
+++ b/samples/net/sockets/echo_client/src/ca_certificate.h
@@ -8,6 +8,7 @@
 #define __CA_CERTIFICATE_H__
 
 #define CA_CERTIFICATE_TAG 1
+#define PSK_TAG 2
 
 #define TLS_PEER_HOSTNAME "localhost"
 
@@ -16,5 +17,9 @@
 static const unsigned char ca_certificate[] = {
 #include "echo-apps-cert.der.inc"
 };
+
+#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+#include CONFIG_NET_SAMPLE_PSK_HEADER_FILE
+#endif
 
 #endif /* __CA_CERTIFICATE_H__ */

--- a/samples/net/sockets/echo_client/src/dummy_psk.h
+++ b/samples/net/sockets/echo_client/src/dummy_psk.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __DUMMY_PSK_H__
+#define __DUMMY_PSK_H__
+
+static const unsigned char psk[] = {0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+static const char psk_id[] = "PSK_identity";
+
+#endif /* __DUMMY_PSK_H__ */

--- a/samples/net/sockets/echo_client/src/echo-client.c
+++ b/samples/net/sockets/echo_client/src/echo-client.c
@@ -227,6 +227,23 @@ static void init_app(void)
 	}
 #endif
 
+#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+	err = tls_credential_add(PSK_TAG,
+				TLS_CREDENTIAL_PSK,
+				psk,
+				sizeof(psk));
+	if (err < 0) {
+		LOG_ERR("Failed to register PSK: %d", err);
+	}
+	err = tls_credential_add(PSK_TAG,
+				TLS_CREDENTIAL_PSK_ID,
+				psk_id,
+				sizeof(psk_id) - 1);
+	if (err < 0) {
+		LOG_ERR("Failed to register PSK ID: %d", err);
+	}
+#endif
+
 	if (IS_ENABLED(CONFIG_NET_CONNECTION_MANAGER)) {
 		net_mgmt_init_event_callback(&mgmt_cb,
 					     event_handler, EVENT_MASK);

--- a/samples/net/sockets/echo_client/src/tcp.c
+++ b/samples/net/sockets/echo_client/src/tcp.c
@@ -136,6 +136,9 @@ static int start_tcp_proto(struct data *data, struct sockaddr *addr,
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 	sec_tag_t sec_tag_list[] = {
 		CA_CERTIFICATE_TAG,
+#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+		PSK_TAG,
+#endif
 	};
 
 	ret = setsockopt(data->tcp.sock, SOL_TLS, TLS_SEC_TAG_LIST,

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -98,6 +98,9 @@ static int start_udp_proto(struct data *data, struct sockaddr *addr,
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 	sec_tag_t sec_tag_list[] = {
 		CA_CERTIFICATE_TAG,
+#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+		PSK_TAG,
+#endif
 	};
 
 	ret = setsockopt(data->udp.sock, SOL_TLS, TLS_SEC_TAG_LIST,

--- a/samples/net/sockets/echo_server/CMakeLists.txt
+++ b/samples/net/sockets/echo_server/CMakeLists.txt
@@ -5,6 +5,18 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(sockets_echo_server)
 
+if(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED AND
+    (CONFIG_NET_SAMPLE_PSK_HEADER_FILE STREQUAL "dummy_psk.h"))
+  add_custom_target(development_psk
+    COMMAND ${CMAKE_COMMAND} -E echo "----------------------------------------------------------"
+    COMMAND ${CMAKE_COMMAND} -E echo "--- WARNING: Using dummy PSK! Only suitable for        ---"
+    COMMAND ${CMAKE_COMMAND} -E echo "--- development. Set NET_SAMPLE_PSK_HEADER_FILE to use ---"
+    COMMAND ${CMAKE_COMMAND} -E echo "--- own pre-shared key.                                ---"
+    COMMAND ${CMAKE_COMMAND} -E echo "----------------------------------------------------------"
+  )
+  add_dependencies(app development_psk)
+endif()
+
 target_sources(                     app PRIVATE src/echo-server.c)
 target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)
 target_sources_ifdef(CONFIG_NET_TCP app PRIVATE src/tcp.c)

--- a/samples/net/sockets/echo_server/Kconfig
+++ b/samples/net/sockets/echo_server/Kconfig
@@ -53,4 +53,12 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 	  Set VLAN (virtual LAN) tag (id) that is used in the sample
 	  application.
 
+config NET_SAMPLE_PSK_HEADER_FILE
+	string "Header file containing PSK"
+	default "dummy_psk.h"
+	depends on MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+	help
+	  Name of a header file containing a
+	  pre-shared key.
+
 source "Kconfig.zephyr"

--- a/samples/net/sockets/echo_server/src/certificate.h
+++ b/samples/net/sockets/echo_server/src/certificate.h
@@ -8,6 +8,7 @@
 #define __CERTIFICATE_H__
 
 #define SERVER_CERTIFICATE_TAG 1
+#define PSK_TAG 2
 
 static const unsigned char server_certificate[] = {
 #include "echo-apps-cert.der.inc"
@@ -17,5 +18,9 @@ static const unsigned char server_certificate[] = {
 static const unsigned char private_key[] = {
 #include "echo-apps-key.der.inc"
 };
+
+#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+#include CONFIG_NET_SAMPLE_PSK_HEADER_FILE
+#endif
 
 #endif /* __CERTIFICATE_H__ */

--- a/samples/net/sockets/echo_server/src/dummy_psk.h
+++ b/samples/net/sockets/echo_server/src/dummy_psk.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __DUMMY_PSK_H__
+#define __DUMMY_PSK_H__
+
+static const unsigned char psk[] = {0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+static const char psk_id[] = "PSK_identity";
+
+#endif /* __DUMMY_PSK_H__ */

--- a/samples/net/sockets/echo_server/src/echo-server.c
+++ b/samples/net/sockets/echo_server/src/echo-server.c
@@ -62,6 +62,23 @@ static void init_app(void)
 	}
 #endif
 
+#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+	err = tls_credential_add(PSK_TAG,
+				TLS_CREDENTIAL_PSK,
+				psk,
+				sizeof(psk));
+	if (err < 0) {
+		LOG_ERR("Failed to register PSK: %d", err);
+	}
+	err = tls_credential_add(PSK_TAG,
+				TLS_CREDENTIAL_PSK_ID,
+				psk_id,
+				sizeof(psk_id) - 1);
+	if (err < 0) {
+		LOG_ERR("Failed to register PSK ID: %d", err);
+	}
+#endif
+
 	init_vlan();
 }
 

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -86,6 +86,9 @@ static int start_tcp_proto(struct data *data,
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 	sec_tag_t sec_tag_list[] = {
 		SERVER_CERTIFICATE_TAG,
+#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+		PSK_TAG,
+#endif
 	};
 
 	ret = setsockopt(data->tcp.sock, SOL_TLS, TLS_SEC_TAG_LIST,

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -51,6 +51,9 @@ static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 	sec_tag_t sec_tag_list[] = {
 		SERVER_CERTIFICATE_TAG,
+#if defined(CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+		PSK_TAG,
+#endif
 	};
 	int role = 1;
 


### PR DESCRIPTION
PSK support is added to echo-client.c.

Enabled by `CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED=y`