### PR TITLE
[nrf fromlist] cmake: zephyr_library_amend feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,8 +479,11 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
     # this binary_dir is created but stays empty. Object files land in
     # the main binary dir instead.
     # https://cmake.org/pipermail/cmake/2019-June/069547.html
+    set(ZEPHYR_CURRENT_MODULE_DIR ${module_path})
     add_subdirectory(${module_path} ${CMAKE_CURRENT_BINARY_DIR}/modules/${module_name})
   endforeach()
+  # Done processing modules, clear ZEPHYR_CURRENT_MODULE_DIR.
+  set(ZEPHYR_CURRENT_MODULE_DIR)
 endif()
 
 set(syscall_macros_h ${ZEPHYR_BINARY_DIR}/include/generated/syscall_macros.h)

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -441,7 +441,7 @@ macro(zephyr_library_amend)
 
   zephyr_library_get_current_dir_lib_name(${ZEPHYR_CURRENT_MODULE_DIR} lib_name)
 
-  set(ZEPHYR_CURRENT_LIBRARY ${lib_name})
+  set(ZEPHYR_CURRENT_LIBRARY ${IMAGE}${lib_name})
 endmacro()
 
 function(zephyr_link_interface interface)

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -384,15 +384,15 @@ endmacro()
 
 # Constructor with a directory-inferred name
 macro(zephyr_library)
-  zephyr_library_get_current_dir_lib_name(lib_name)
+  zephyr_library_get_current_dir_lib_name(${ZEPHYR_BASE} lib_name)
   zephyr_library_named(${lib_name})
 endmacro()
 
-# Determines what the current directory's lib name would be and writes
-# it to the argument "lib_name"
-macro(zephyr_library_get_current_dir_lib_name lib_name)
+# Determines what the current directory's lib name would be according to the
+# provided base and writes it to the argument "lib_name"
+macro(zephyr_library_get_current_dir_lib_name base lib_name)
   # Remove the prefix (/home/sebo/zephyr/driver/serial/CMakeLists.txt => driver/serial/CMakeLists.txt)
-  file(RELATIVE_PATH name ${ZEPHYR_BASE} ${CMAKE_CURRENT_LIST_FILE})
+  file(RELATIVE_PATH name ${base} ${CMAKE_CURRENT_LIST_FILE})
 
   # Remove the filename (driver/serial/CMakeLists.txt => driver/serial)
   get_filename_component(name ${name} DIRECTORY)
@@ -415,6 +415,34 @@ macro(zephyr_library_named name)
   target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PUBLIC ${IMAGE}zephyr_interface)
 endmacro()
 
+# Provides amend functionality to a Zephyr library for out-of-tree usage.
+#
+# When called from a Zephyr module, the corresponding zephyr library defined
+# within Zephyr will be looked up.
+#
+# Note, in order to ensure correct library when amending, the folder structure in the
+# Zephyr module must resemble the structure used in Zephyr, as example:
+#
+# Example: to amend the zephyr library created in
+# ZEPHYR_BASE/drivers/entropy/CMakeLists.txt
+# add the following file:
+# ZEPHYR_MODULE/drivers/entropy/CMakeLists.txt
+# with content:
+# zephyr_library_amend()
+# zephyr_libray_add_sources(...)
+#
+macro(zephyr_library_amend)
+  # This is a macro because we need to ensure the ZEPHYR_CURRENT_LIBRARY and
+  # following zephyr_library_* calls are executed within the scope of the
+  # caller.
+  if(NOT ZEPHYR_CURRENT_MODULE_DIR)
+    message(FATAL_ERROR "Function only available for Zephyr modules.")
+  endif()
+
+  zephyr_library_get_current_dir_lib_name(${ZEPHYR_CURRENT_MODULE_DIR} lib_name)
+
+  set(ZEPHYR_CURRENT_LIBRARY ${lib_name})
+endmacro()
 
 function(zephyr_link_interface interface)
   target_link_libraries(${interface} INTERFACE ${IMAGE}zephyr_interface)


### PR DESCRIPTION
This PR allows amending to a Zephyr library created inside Zephyr repo in a generic way.

Currently, if no files are added to a library, as example the drivers/entropy zephyr library because no drivers (c-files) are selected using Kconfig, the following error when running cmake / menuconfig:

```
CMake Error at /projects/github/ncs/zephyr/cmake/extensions.cmake:411 (add_library):                       
  No SOURCES given to target: drivers__entropy
Call Stack (most recent call first):
  /projects/github/ncs/zephyr/cmake/extensions.cmake:388 (zephyr_library_named)
  /projects/github/ncs/zephyr/drivers/entropy/CMakeLists.txt:3 (zephyr_library)
```

This PR allows to amend drivers files out-of-tree to an existing zephyr library.

As example:
`drivers/entropy/CMakeLists.txt` creates a zephyr library as:
```
 zephyr_library()
```
but due to kconfig settings, no files are added to the lib in Zephyr.
   
The amend function allows to amend to such a lib, by creating a
CMakeLists.txt file following identical folder structure in a Zephyr Module:
```
    <zephyr_module_oot>/drivers/entropy/CMakeLists.txt
    zephyr_library_amend()
    zephyr_library_sources() # Sources are amended to the original library
```
which means that the library created in Zephyr is no longer empty.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>