### PR TITLE
[nrf fromtree] Test: Settings: Fix FCB delete test

### DIFF
--- a/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_delete_fcb.c
@@ -37,8 +37,10 @@ void test_config_delete_fcb(void)
 	zassert_true(rc == 0, "fcb redout error");
 	zassert_true(val8 == 153U, "bad value read");
 
+	val8 = 0x55;
+
 	settings_delete("myfoo/mybar");
 	rc = settings_load();
 	zassert_true(rc == 0, "fcb redout error");
-	zassert_true(val8 == VAL8_DELETED, "bad value read");
+	zassert_true(val8 == 0x55, "bad value read");
 }


### PR DESCRIPTION
This commit fixes the FCB delete test after PR #19541.
Now the entity callback is not called on deleted element.

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>
Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>