### PR TITLE
[nrf fromlist] cmake: ensure zephyr_module.py creates posix path output

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -87,8 +87,9 @@ def process_module(module, cmake_out=None, kconfig_out=None):
     cmake_path = os.path.join(module, cmake_setting or 'zephyr')
     cmake_file = os.path.join(cmake_path, 'CMakeLists.txt')
     if os.path.isfile(cmake_file) and cmake_out is not None:
-        cmake_out.write('\"{}\":\"{}\"\n'.format(os.path.basename(module),
-                                                 os.path.abspath(cmake_path)))
+        cmake_out.write('\"{}\":\"{}\"\n'
+                        .format(os.path.basename(module), PurePath(
+                            os.path.abspath(cmake_path)).as_posix()))
 
     kconfig_file = os.path.join(module, kconfig_setting or 'zephyr/Kconfig')
     if os.path.isfile(kconfig_file) and kconfig_out is not None:


### PR DESCRIPTION
This commit fixes an issue in windows where zephyr_modules.txt contains
a \ as path separator.
This causes issues later when using the path generated by
zephyr_module.txt are used as variables in CMake on windows.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>