### PR TITLE
[nrf fromlist] boards: arm: nrf9160_pca10090: increase reset line wait time

### DIFF
--- a/boards/arm/nrf9160_pca10090/nrf52840_reset.c
+++ b/boards/arm/nrf9160_pca10090/nrf52840_reset.c
@@ -55,7 +55,7 @@ int bt_hci_transport_setup(struct device *h4)
 	 * It is critical (!) to wait here, so that all bytes
 	 * on the lines are received and drained correctly.
 	 */
-	k_sleep(K_MSEC(1));
+	k_sleep(K_MSEC(10));
 
 	/* Drain bytes */
 	while (uart_fifo_read(h4, &c, 1)) {


### PR DESCRIPTION
The reset line wait time of 1 ms has been shown to not be enough for the reset. Increasing to 10 ms.

Signed-off-by: Sigurd Olav Nevstad <sigurdolav.nevstad@nordicsemi.no>