### PR TITLE
[nrf fromlist] cmake: app mem partion flexibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1086,7 +1086,7 @@ if(CONFIG_USERSPACE)
     -d ${OBJ_FILE_DIR}
     -o ${APP_SMEM_UNALIGNED_LD}
     ${NEWLIB_PART} ${MBEDTLS_PART}
-    $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
+    $<TARGET_PROPERTY:${IMAGE}zephyr_property_target,COMPILE_OPTIONS>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS
     kernel
@@ -1137,7 +1137,7 @@ if(CONFIG_USERSPACE)
     -e $<TARGET_FILE:app_smem_unaligned_prebuilt>
     -o ${APP_SMEM_ALIGNED_LD}
     ${NEWLIB_PART} ${MBEDTLS_PART}
-    $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
+    $<TARGET_PROPERTY:${IMAGE}zephyr_property_target,COMPILE_OPTIONS>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS
     ${KERNEL_LIBRARY}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1086,11 +1086,13 @@ if(CONFIG_USERSPACE)
     -d ${OBJ_FILE_DIR}
     -o ${APP_SMEM_UNALIGNED_LD}
     ${NEWLIB_PART} ${MBEDTLS_PART}
+    $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS
     kernel
     ${ZEPHYR_LIBS_PROPERTY}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
+    COMMAND_EXPAND_LISTS
     COMMENT "Generating app_smem_unaligned linker section"
     )
 
@@ -1135,12 +1137,14 @@ if(CONFIG_USERSPACE)
     -e $<TARGET_FILE:app_smem_unaligned_prebuilt>
     -o ${APP_SMEM_ALIGNED_LD}
     ${NEWLIB_PART} ${MBEDTLS_PART}
+    $<TARGET_PROPERTY:zephyr_property_target,COMPILE_OPTIONS>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     DEPENDS
     ${KERNEL_LIBRARY}
     ${ZEPHYR_LIBS_PROPERTY}
     app_smem_unaligned_prebuilt
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/
+    COMMAND_EXPAND_LISTS
     COMMENT "Generating app_smem_aligned linker section"
     )
 endif()

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -630,6 +630,13 @@ if(CONFIG_QEMU_TARGET)
   endif()
 endif()
 
+# General purpose Zephyr target.
+# This target can be used for custom zephyr settings that needs to be used elsewhere in the build system
+#
+# Currently used properties:
+# - COMPILES_OPTIONS: Used by application memory partition feature
+add_custom_target(zephyr_property_target)
+
 # "app" is a CMake library containing all the application code and is
 # modified by the entry point ${APPLICATION_SOURCE_DIR}/CMakeLists.txt
 # that was specified when cmake was called.

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -635,7 +635,7 @@ endif()
 #
 # Currently used properties:
 # - COMPILES_OPTIONS: Used by application memory partition feature
-add_custom_target(zephyr_property_target)
+add_custom_target(${IMAGE}zephyr_property_target)
 
 # "app" is a CMake library containing all the application code and is
 # modified by the entry point ${APPLICATION_SOURCE_DIR}/CMakeLists.txt

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -531,7 +531,7 @@ endfunction()
 # Note: Ensure the given partition has been define using
 #       K_APPMEM_PARTITION_DEFINE in source code.
 function(zephyr_library_app_memory partition)
-  set_property(TARGET zephyr_property_target
+  set_property(TARGET ${IMAGE}zephyr_property_target
                APPEND PROPERTY COMPILE_OPTIONS
                "-l" $<TARGET_FILE_NAME:${ZEPHYR_CURRENT_LIBRARY}> "${partition}")
 endfunction()

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -523,6 +523,19 @@ function(zephyr_library_import library_name library_path)
   zephyr_append_cmake_library(${library_name})
 endfunction()
 
+# Place the current zephyr library in the application memory partition.
+#
+# The partition argument is the name of the partition where the library shall
+# be placed.
+#
+# Note: Ensure the given partition has been define using
+#       K_APPMEM_PARTITION_DEFINE in source code.
+function(zephyr_library_app_memory partition)
+  set_property(TARGET zephyr_property_target
+               APPEND PROPERTY COMPILE_OPTIONS
+               "-l" $<TARGET_FILE_NAME:${ZEPHYR_CURRENT_LIBRARY}> "${partition}")
+endfunction()
+
 # 1.2.1 zephyr_interface_library_*
 #
 # A Zephyr interface library is a thin wrapper over a CMake INTERFACE

--- a/doc/reference/usermode/memory_domain.rst
+++ b/doc/reference/usermode/memory_domain.rst
@@ -284,8 +284,13 @@ top-level ``CMakeLists.txt`` adds the following:
 
     gen_app_partitions.py ... --library libc.a z_libc_partition ..
 
-There is no support for expressing this in the project-level configuration
-or build files; the toplevel ``CMakeLists.txt`` must be edited.
+For pre-compiled libraries there is no support for expressing this in the
+project-level configuration or build files; the toplevel ``CMakeLists.txt`` must
+be edited.
+
+For Zephyr libraries created using ``zephyr_library`` or ``zephyr_library_named``
+the ``zephyr_library_app_memory`` function can be used to specify the memory
+partition where all globals in the library should be placed.
 
 Pre-defined Memory Partitions
 -----------------------------


### PR DESCRIPTION
See also: https://github.com/zephyrproject-rtos/zephyr/pull/20333

This commit allows a more dynamic approach for specifying that a zephyr
library must be placed in a dedicated app memomory partition.
This is still done by defining the partition in code using
K_APPMEM_PARTITION_DEFINE, but now the zephyr library can be added to
the generation of partition table using zephyr_library_app_memory
instead of modifying the overall zephyr/CMakeLists.txt file.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>