### PR TITLE
[nrf noup] revert: "943a8651224470b6594e"

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -220,14 +220,6 @@ set(SPHINX_BUILD_HTML_COMMAND
   ${CMAKE_COMMAND} -E env
   ZEPHYR_BASE=${ZEPHYR_BASE}
   ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-
-  # nRF-specific hack to pass these through to nrf/doc/zephyr/conf.py (the
-  # Sphinx configuration file). We use it for Intersphinx. See
-  # nrf/doc/CMakeLists.txt.
-  ZEPHYR_OUTPUT=${SPHINX_OUTPUT_DIR}
-  ZEPHYR_RST_SRC=${RST_OUT}/doc
-  KCONFIG_OUTPUT=${KCONFIG_OUTPUT}
-
   ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_HTML})
 
 # The sphinx-html target is provided as a convenience for incremental
@@ -332,10 +324,7 @@ endif()
 #
 # Dependencies and final targets
 #
-
-# nRF-specific: No 'kconfig' dependency here, because we use a shared Kconfig
-# documentation set instead
-add_dependencies(html content doxy_real_modified_times)
+add_dependencies(html content doxy_real_modified_times kconfig)
 
 add_custom_target(
   htmldocs

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -3,13 +3,11 @@
 API Reference
 #############
 
-.. nRF-specific: There's a shared Kconfig documentation set, so
-   no kconfig/index.rst below
-
 .. toctree::
    :maxdepth: 1
 
    bluetooth/index.rst
+   kconfig/index.rst
    drivers/index.rst
    display/index.rst
    file_system/index.rst


### PR DESCRIPTION
This reverts commit 943a8651224470b6594e992fd2c58a454540796a.

This commit should have been applied simultaneously with a commit in
nrf but it was not and is now causing problems.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>