### PR TITLE
[nrf fromtree] Bluetooth: Kconfig: Fix host phy and data length update

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -132,14 +132,12 @@ config BT_REMOTE_VERSION
 
 config BT_PHY_UPDATE
 	bool "PHY Update"
-	depends on BT_CTLR_PHY_UPDATE_SUPPORT
 	default y
 	help
 	  Enable support for Bluetooth 5.0 PHY Update Procedure.
 
 config BT_DATA_LEN_UPDATE
 	bool "Data Length Update"
-	depends on BT_CTLR_DATA_LEN_UPDATE_SUPPORT
 	default y
 	help
 	  Enable support for Bluetooth v4.2 LE Data Length Update procedure.


### PR DESCRIPTION
Fix dependency on the Host to include the PHY update procedure and the
data length update procedure. In a host-only build this feature should
be possible to select without relying on the supported features of the
controller. The host will check support using HCI command to read
attached controller features and commands supported.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>