### PR TITLE
[nrf noup] west: multi-image: Change variable used to find app dir

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -293,8 +293,8 @@ class Build(Forceable):
         if not self.cmake_cache:
             return          # That's all we can check without a cache.
 
-        cached_app = self.cmake_cache.get('APPLICATION_SOURCE_DIR')
-        log.dbg('APPLICATION_SOURCE_DIR:', cached_app,
+        cached_app = self.cmake_cache.get('CMAKE_HOME_DIRECTORY')
+        log.dbg('CMAKE_HOME_DIRECTORY:', cached_app,
                 level=log.VERBOSE_EXTREME)
         source_abs = (os.path.abspath(self.args.source_dir)
                       if self.args.source_dir else None)


### PR DESCRIPTION
APPLICATION_SOURCE_DIR is not in the cache due to multi-image
requiring cache variables to be image-prefixed and due to a desire to
not image-prefix this variable.

But west expects it to be so. To resolve this, have west use a
different variable that points to the same thing.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>