### PR TITLE
[nrf noup] settings: Fix NVS initialization with PM enabled

### DIFF
--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -152,7 +152,7 @@ int settings_backend_init(void)
 		return rc;
 	}
 
-	rc = flash_area_get_sectors(DT_FLASH_AREA_STORAGE_ID, &sector_cnt,
+	rc = flash_area_get_sectors(FLASH_AREA_STORAGE_ID, &sector_cnt,
 				    &hw_flash_sector);
 	if (rc == -ENODEV) {
 		return rc;


### PR DESCRIPTION
New code was introduced upstream, which is not PM-aware. In result NVS
settings backend initialization failed on nRF91.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>