### PR TITLE
[nrf noup] settings: Lower partition settings storage to 0x2000

### DIFF
--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -18,7 +18,7 @@ source "subsys/logging/Kconfig.template.log_config"
 # nrf/subsys/partition_manager/Kconfig.template.partition_size
 config PM_PARTITION_SIZE_SETTINGS_STORAGE
 	hex "Flash space reserved for settings storage partition"
-	default 0x6000
+	default 0x2000
 	help
 	  Flash space set aside for the settings storage partition.
 endif


### PR DESCRIPTION
NCSDK-3857: Lowering so we don't use too much settings storage by
default.

@hakonfam @ppryga 