### PR TITLE
net: mqtt: Maintain count of PINGREQ awaiting response

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -499,6 +499,9 @@ struct mqtt_client {
 	/** MQTT protocol version. */
 	u8_t protocol_version;
 
+	/** Unanswered PINGREQ count on this connection. */
+	s8_t unacked_ping;
+
 	/** Will retain flag, 1 if will message shall be retained persistently.
 	 */
 	u8_t will_retain : 1;

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -111,6 +111,9 @@ static int client_connect(struct mqtt_client *client)
 
 	client->internal.last_activity = mqtt_sys_tick_in_ms_get();
 
+	/* Reset the unanswered ping count for a new connection */
+	client->unacked_ping = 0;
+
 	MQTT_TRC("Connect completed");
 
 	return 0;
@@ -547,6 +550,8 @@ int mqtt_ping(struct mqtt_client *client)
 	}
 
 	err_code = client_write(client, packet.cur, packet.end - packet.cur);
+
+	client->unacked_ping++;
 
 error:
 	mqtt_mutex_unlock(client);

--- a/subsys/net/lib/mqtt/mqtt_rx.c
+++ b/subsys/net/lib/mqtt/mqtt_rx.c
@@ -120,6 +120,13 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 	case MQTT_PKT_TYPE_PINGRSP:
 		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PINGRSP!", client);
 
+		if (client->unacked_ping <= 0) {
+			MQTT_TRC("Unexpected PINGRSP");
+			client->unacked_ping = 0;
+		} else {
+			client->unacked_ping--;
+		}
+
 		/* No notification of Ping response to application. */
 		notify_event = false;
 		break;


### PR DESCRIPTION
Maintain a simple count of how many PINGREQ have been sent for the
current connection that have not had a corresponding PINGRESP.  Nothing
is done with this information internal to the MQTT driver, but it is
exposed to the application layer to monitor as desired.

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>