### PR TITLE
Revert "[nrf temphack] cortex_m: linker: Add ext_abi section"

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -285,11 +285,6 @@ SECTIONS
 #include <linker/priv_stacks-rom.ld>
 #include <linker/kobject-rom.ld>
 
-	. = ALIGN(4);
-	_ext_abis_start = .;
-	KEEP(*(.ext_abis))
-	_ext_abis_size = ABSOLUTE((. - _ext_abis_start) / 4);
-
 	/*
 	 * For XIP images, in order to avoid the situation when __data_rom_start
 	 * is 32-bit aligned, but the actual data is placed right after rodata


### PR DESCRIPTION
This reverts commit 4cc4339719d422995e65a48c09b8ed6572505bd4.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>