### PR TITLE
Revert "[nrf noup] west: multi-image: Change variable used [...]"

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -293,8 +293,8 @@ class Build(Forceable):
         if not self.cmake_cache:
             return          # That's all we can check without a cache.
 
-        cached_app = self.cmake_cache.get('CMAKE_HOME_DIRECTORY')
-        log.dbg('CMAKE_HOME_DIRECTORY:', cached_app,
+        cached_app = self.cmake_cache.get('APPLICATION_SOURCE_DIR')
+        log.dbg('APPLICATION_SOURCE_DIR:', cached_app,
                 level=log.VERBOSE_EXTREME)
         source_abs = (os.path.abspath(self.args.source_dir)
                       if self.args.source_dir else None)


### PR DESCRIPTION
This reverts commit 58ee03b3ab9f9effcfb4d2c5b2bcff616db08f9f.

The commit was previously needed for multi-image and is therefore no
longer needed.

An nrf PR for updating west.yml correspondingly will not be created as there is no rush to get this in.