### PR TITLE
Revert "[nrf temphack] ci: work around sanitycheck issue"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
 
       // ENVs for sanitycheck
       ARCH = "-a arm"
-      SANITYCHECK_OPTIONS = "--inline-logs --enable-coverage -N" // DEFAULT: --testcase-root tests
+      SANITYCHECK_OPTIONS = "--inline-logs --enable-coverage --coverage-platform arm -N" // DEFAULT: --testcase-root tests
       SANITYCHECK_RETRY_CMDS = '' // initialized so that it is shared to parrallel stages
   }
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1696,11 +1696,7 @@ class TestInstance:
             if self.testcase.extra_configs:
                 content = "\n".join(self.testcase.extra_configs)
 
-            # It has been observed in NCS CI that
-            # options.coverage_platform is None. It is not yet
-            # understood how this can happen. To deal, we null-check
-            # it.
-            if options.enable_coverage and options.coverage_platform:
+            if options.enable_coverage:
                 if platform.name in options.coverage_platform:
                     content = content + "\nCONFIG_COVERAGE=y"
 


### PR DESCRIPTION
This PR adds the appropriate coverage platform to avoid the issue that 4a309fb9baa47cef7242e9c46f951653321ae907 was fixing, and then
reverts the previous fix.