### PR TITLE
[nrf noup] cmake: include nrf reports cmake from repo

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -17,13 +17,3 @@ foreach(report ram_report rom_report)
             $<TARGET_PROPERTY:zephyr_property_target,${report}_DEPENDENCIES>
     )
 endforeach()
-
-add_custom_command(
-  TARGET rom_report
-  POST_BUILD
-  COMMAND
-  ${PYTHON_EXECUTABLE}
-  ${ZEPHYR_BASE}/../nrf/scripts/partition_manager_report.py
-  --input ${CMAKE_BINARY_DIR}/partitions.yml
-  "$<$<NOT:$<TARGET_EXISTS:partition_manager>>:--quiet>"
-  )


### PR DESCRIPTION
To make patches simpler and diff smaller.

nrf pr https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1741

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>