### PR TITLE
[nrf noup] ci: python requirement updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -333,7 +333,9 @@ def generateComplianceStage(AGENT_LABELS, DOCKER_REG, IMAGE_TAG, JOB_NAME, CI_ST
 
               // Run the compliance check
               try {
-                sh "(source ../zephyr/zephyr-env.sh && ../tools/ci-tools/scripts/check_compliance.py $COMPLIANCE_ARGS --commits $COMMIT_RANGE)"
+                sh "source ../zephyr/zephyr-env.sh &&  \
+                    pip install --user -r ../tools/ci-tools/requirements.txt && \
+                    ../tools/ci-tools/scripts/check_compliance.py $COMPLIANCE_ARGS --commits $COMMIT_RANGE"
               }
               finally {
                 junit 'compliance.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,10 +120,12 @@ pipeline {
       }
 
       CI_STATE.SELF.IS_MERGEUP = false
-      if (((CI_STATE.SELF.CHANGE_TITLE.toLowerCase().contains('mergeup')  ) || (CI_STATE.SELF.CHANGE_TITLE.toLowerCase().contains('upmerge')  )) &&
-          ((CI_STATE.SELF.CHANGE_BRANCH.toLowerCase().contains('mergeup') ) || (CI_STATE.SELF.CHANGE_BRANCH.toLowerCase().contains('upmerge') ))) {
-        CI_STATE.SELF.IS_MERGEUP = true
-        println 'This is a MERGE-UP PR.   CI_STATE.SELF.IS_MERGEUP=' + CI_STATE.SELF.IS_MERGEUP
+      if (CI_STATE.SELF.containsKey('CHANGE_TITLE')) {
+        if (((CI_STATE.SELF.CHANGE_TITLE.toLowerCase().contains('mergeup')  ) || (CI_STATE.SELF.CHANGE_TITLE.toLowerCase().contains('upmerge')  )) &&
+            ((CI_STATE.SELF.CHANGE_BRANCH.toLowerCase().contains('mergeup') ) || (CI_STATE.SELF.CHANGE_BRANCH.toLowerCase().contains('upmerge') ))) {
+          CI_STATE.SELF.IS_MERGEUP = true
+          println 'This is a MERGE-UP PR.   CI_STATE.SELF.IS_MERGEUP=' + CI_STATE.SELF.IS_MERGEUP
+        }
       }
 
       if (CI_STATE.SELF.CRON == 'COMMIT') {

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -16,12 +16,12 @@ pykwalify
 pyocd>=0.24.0
 pyserial
 pytest
-sphinx>=1.7.5
+sphinx>=1.7.5, != 2.4.0
 sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 tabulate
-west>=0.6.2
+west>=0.6.3, !=0.7.*
 wheel>=0.30.0
 # "win32" is used for 64-bit Windows as well
 windows-curses; sys_platform == "win32"


### PR DESCRIPTION
- Install ci-tools requirementx.txt before check_compliance.py
-- missing python-magic

- edit python requirement versions
-- setting sphinx!=2.4.0
-- (sphinx:2.4.0 released yesterday with a bug that breaks the build)

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>