### PR TITLE
Erratum 19 - SPU flash regions are 32 kB instead of 16 kB

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/tz/secure_entry_functions.ld
+++ b/arch/arm/core/aarch32/cortex_m/tz/secure_entry_functions.ld
@@ -4,18 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* nRF-specific defines. */
+#ifdef CONFIG_CPU_HAS_NRF_IDAU
+	/* This SOC needs the NSC region to be at the end of an SPU region. */
+	#define NSC_ALIGN \
+		. = ALIGN(CONFIG_NRF_SPU_FLASH_REGION_SIZE) \
+			- (1 << LOG2CEIL(__sg_size))
+	#define NSC_ALIGN_END . = ALIGN(CONFIG_NRF_SPU_FLASH_REGION_SIZE)
+#endif /* CONFIG_CPU_HAS_NRF_IDAU */
+
+
 #if CONFIG_ARM_NSC_REGION_BASE_ADDRESS != 0
 	#define NSC_ALIGN . = ABSOLUTE(CONFIG_ARM_NSC_REGION_BASE_ADDRESS)
-#elif defined(CONFIG_CPU_HAS_NRF_IDAU)
-	/* The nRF9160 needs the NSC region to be at the end of a 32 kB region. */
-	#define NSC_ALIGN . = ALIGN(0x8000) - (1 << LOG2CEIL(__sg_size))
-#else
+#elif !defined(NSC_ALIGN)
 	#define NSC_ALIGN . = ALIGN(4)
-#endif
+#endif /* CONFIG_ARM_NSC_REGION_BASE_ADDRESS */
 
-#ifdef CONFIG_CPU_HAS_NRF_IDAU
-	#define NSC_ALIGN_END . = ALIGN(0x8000)
-#else
+#ifndef NSC_ALIGN_END
 	#define NSC_ALIGN_END . = ALIGN(4)
 #endif
 
@@ -31,11 +36,14 @@ __sg_size = __sg_end - __sg_start;
 NSC_ALIGN_END;
 __nsc_size = . - __sg_start;
 
+/* nRF-specific ASSERT. */
 #ifdef CONFIG_CPU_HAS_NRF_IDAU
-	ASSERT(1 << LOG2CEIL(0x8000 - (__sg_start % 0x8000))
-			 == (0x8000 - (__sg_start % 0x8000))
-		&& (0x8000 - (__sg_start % 0x8000)) >= 32
-		&& (0x8000 - (__sg_start % 0x8000)) <= 4096,
+	#define NRF_SG_START (__sg_start % CONFIG_NRF_SPU_FLASH_REGION_SIZE)
+	#define NRF_SG_SIZE (CONFIG_NRF_SPU_FLASH_REGION_SIZE - NRF_SG_START)
+	ASSERT((__sg_size == 0)
+		|| (((1 << LOG2CEIL(NRF_SG_SIZE)) == NRF_SG_SIZE) /* Pow of 2 */
+			&& (NRF_SG_SIZE >= 32)
+			&& (NRF_SG_SIZE <= 4096)),
 		"The Non-Secure Callable region size must be a power of 2 \
 between 32 and 4096 bytes.")
 #endif

--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -41,6 +41,22 @@ config CPU_HAS_NRF_IDAU
 	  (IDAU: "Implementation-Defined Attribution Unit", in accordance with
 	  ARM terminology).
 
+if CPU_HAS_NRF_IDAU
+config NRF_SPU_FLASH_REGION_SIZE
+	hex
+	default 0x8000 if SOC_NRF9160
+	default 0x8000 if SOC_NRF5340_CPUAPP && NRF5340_CPUAPP_ERRATUM19
+	default 0x4000 if SOC_NRF5340_CPUAPP
+	help
+	  FLASH region size for the NRF_SPU peripheral
+
+config NRF_SPU_RAM_REGION_SIZE
+	hex
+	default 0x2000 if SOC_NRF9160 || SOC_NRF5340_CPUAPP
+	help
+	  RAM region size for the NRF_SPU peripheral
+endif
+
 config CPU_HAS_FPU_DOUBLE_PRECISION
 	bool
 	depends on CPU_CORTEX_M7

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.nrf5340_CPUAPP_QKAA
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.nrf5340_CPUAPP_QKAA
@@ -11,4 +11,18 @@ config SOC
 config NUM_IRQS
 	default 69
 
+config NRF5340_CPUAPP_ERRATUM19
+	bool "Include workarounds for Erratum 19"
+	default y
+	depends on !TRUSTED_EXECUTION_NONSECURE
+	help
+	  This anomaly applies to IC Rev. Engineering A, build codes QKAA-AB0.
+	  This config MUST be enabled if there is a chance the code will be run
+	  on nRF5340 Engineering A. Enabling this config is safe on other
+	  nRF5340 variants, but might increase flash size.
+	  The workaround involves adding run-time checks when using the SPU,
+	  and aligning regions on 32 KiB instead of 16 KiB if they are to be
+	  locked with the SPU.
+	  More info: https://infocenter.nordicsemi.com/topic/errata_nRF5340_EngA/ERR/nRF5340/EngineeringA/latest/anomaly_340_19.html?cp=3_0_1_0_1_15
+
 endif # SOC_NRF5340_CPUAPP_QKAA

--- a/soc/arm/nordic_nrf/nrf53/soc.h
+++ b/soc/arm/nordic_nrf/nrf53/soc.h
@@ -29,4 +29,8 @@
 #define FLASH_PAGE_MAX_CNT  128UL
 #endif
 
+#ifdef CONFIG_SOC_NRF5340_CPUAPP
+bool nrf53_has_erratum19(void);
+#endif
+
 #endif /* _NORDICSEMI_NRF53_SOC_H_ */


### PR DESCRIPTION
This PR adds a kconfig for nRF53 erratum 19 (https://infocenter.nordicsemi.com/topic/errata_nRF5340_EngA/ERR/nRF5340/EngineeringA/latest/anomaly_340_19.html?cp=3_0_1_0_1_15).

Review the solution conceptually, and if you see any problems in putting this upstream as is.

@bjorn-tore-taraldsen: Please review the wording on the config in particular.
