### PR TITLE
[nrf fromlist] cmake: Invoke west topdir only with version >= 0.7.1

### DIFF
--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -38,7 +38,7 @@ else()
   # even after output is one line.
   message(STATUS "Found west: ${WEST} (found suitable version \"${west_version}\", minimum required is \"${MIN_WEST_VERSION}\")")
 
-  if (${west_version} VERSION_GREATER_EQUAL "0.7.0")
+  if (${west_version} VERSION_GREATER_EQUAL "0.7.1")
     execute_process(
       COMMAND ${WEST}  topdir
       OUTPUT_VARIABLE  WEST_TOPDIR


### PR DESCRIPTION
West version 0.7.0 introduced `west topdir` command.
Unfortunately version 0.7.0 would print the path in windows path style
when executed in Windows.

This commit ensure that `west topdir` is only used if west >= 0.7.1.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>