### PR TITLE
[nrf fromtree] cmake: Allow projects to add additional ...

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -193,6 +193,7 @@ foreach(target flash debug debugserver attach)
       ${target}
       --skip-rebuild
       DEPENDS ${FLASH_DEPS}
+              $<TARGET_PROPERTY:zephyr_property_target,FLASH_DEPENDENCIES>
       WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
       )
 


### PR DESCRIPTION
...dependencies to flash target

SHA: c09663efd4e

Using zephyr_target_property::FLASH_DEPENDENCIES to fetch additional
dependencies to the flash operation.

The properties are fetched using a generator expression which allows
users of Zephyr to add dependencies both before and after the flash
target has been defined.

Dependencies can be other targets that must be build / custom commands
which must be executed before the flash operation. Or it can be targets
which must be built.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>
Signed-off-by: Haakon Oeye Amundsen <haakon.amundsen@nordicsemi.no>