### PR TITLE
[nrf noup] ci: keep py-Sphinx on v2.x.x

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -16,7 +16,7 @@ pykwalify
 pyocd>=0.24.0
 pyserial
 pytest
-sphinx>=1.7.5, != 2.4.0
+sphinx>=1.7.5, <3.0.0
 sphinx_rtd_theme
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
v3.0 is causing problems

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>