### PR TITLE
Ensure buffer passed to nrfx_qspi_read is word aligned

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -502,11 +502,16 @@ static int qspi_nor_read(struct device *dev, off_t addr, void *dest,
 		return -EINVAL;
 	}
 
+	u8_t buffer[size] __attribute__ ((aligned (32)));
+
 	qspi_lock(dev);
 
-	int ret = nrfx_qspi_read(dest, size, addr);
+	int ret = nrfx_qspi_read(buffer, size, addr);
 
 	qspi_wait_for_completion(dev);
+
+	memcpy(dest, buffer, size);
+
 	return qspi_get_zephyr_ret_code(ret);
 }
 


### PR DESCRIPTION
`nrfx_qspi_read` requires that the buffer passed is word aligned.

The Zephyr flash API doesn't require this. As such, it may be that the passed buffer is not word aligned (as is the case when combined with the FS subsystem).

Submitting this here for feedback before submitting to upstream Zephyr.