### PR TITLE
[nrf noup] cmake: change how path to subsys pm.yml is set

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1586,9 +1586,14 @@ endfunction()
 # manager configurations.
 function(add_partition_manager_config config_file)
   get_filename_component(pm_path ${config_file} REALPATH)
+
   set_property(
     GLOBAL APPEND PROPERTY
-    PM_SUBSYS
-    ${pm_path}
+    PM_SUBSYS_PATH ${pm_path}
+    )
+
+  set_property(
+    GLOBAL APPEND PROPERTY
+    PM_SUBSYS_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}
     )
 endfunction()


### PR DESCRIPTION
The relative path from the build dir to the binary dir of a subsys
folder is not static. In a zephyr subsys it is

build/zephyr/subsys/path

whereas in a nrf subsys it is

build/modules/nrf/subsys/path

The previous way of setting the path to preprocessed pm.yml files
for subsystems only worked with the first of these.

This commit introduces the use of a cmake variable for the binary dir,
and a mechanism for setting the build dir path for each pm.yml
explicitly.

See https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/2122