### PR TITLE
[nrf noup] cmake: move pm patches from zephyr to nrf

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1584,22 +1584,3 @@ function(generate_unique_target_name_from_filename filename target_name)
 
   set(${target_name} gen_${x}_${unique_chars} PARENT_SCOPE)
 endfunction()
-
-# Usage:
-#   add_partition_manager_config(pm.yml)
-#
-# Will add all configurations defined in pm.yml to the global list of partition
-# manager configurations.
-function(add_partition_manager_config config_file)
-  get_filename_component(pm_path ${config_file} REALPATH)
-
-  set_property(
-    GLOBAL APPEND PROPERTY
-    PM_SUBSYS_PATH ${pm_path}
-    )
-
-  set_property(
-    GLOBAL APPEND PROPERTY
-    PM_SUBSYS_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}
-    )
-endfunction()

--- a/subsys/fs/CMakeLists.txt
+++ b/subsys/fs/CMakeLists.txt
@@ -14,8 +14,6 @@ if(CONFIG_FILE_SYSTEM)
 
   target_link_libraries_ifdef(CONFIG_FAT_FILESYSTEM_ELM   FS INTERFACE ELMFAT)
   target_link_libraries_ifdef(CONFIG_FILE_SYSTEM_LITTLEFS FS INTERFACE LITTLEFS)
-
-  add_partition_manager_config(pm.yml)
 endif()
 
 add_subdirectory_ifdef(CONFIG_FCB  ./fcb)

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -35,14 +35,6 @@ config FILE_SYSTEM_LITTLEFS
 	help
 	  Enables LittleFS file system support.
 
-# This config must be compatible with
-# nrf/subsys/partition_manager/Kconfig.template.partition_size
-config PM_PARTITION_SIZE_LITTLEFS
-	hex "Flash space reserved for LittleFS storage partition"
-	default 0x6000
-	help
-	  Flash space set aside for the LittleFS storage partition.
-
 config FILE_SYSTEM_SHELL
 	bool "Enable file system shell"
 	depends on SHELL

--- a/subsys/fs/pm.yml
+++ b/subsys/fs/pm.yml
@@ -1,7 +1,0 @@
-#include <autoconf.h>
-
-#ifdef CONFIG_FILE_SYSTEM_LITTLEFS
-littlefs_storage:
-  placement: {after: [mcuboot_storage, app]}
-  size: CONFIG_PM_PARTITION_SIZE_LITTLEFS
-#endif

--- a/subsys/settings/CMakeLists.txt
+++ b/subsys/settings/CMakeLists.txt
@@ -4,8 +4,3 @@ add_subdirectory(src)
 zephyr_include_directories(
   include
   )
-
-if (CONFIG_SETTINGS_FCB OR CONFIG_SETTINGS_NVS)
-  # These settings backends require a partition in flash
-  add_partition_manager_config(pm.yml)
-endif()

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -13,14 +13,6 @@ if SETTINGS
 module = SETTINGS
 module-str = settings
 source "subsys/logging/Kconfig.template.log_config"
-
-# This config must be compatible with
-# nrf/subsys/partition_manager/Kconfig.template.partition_size
-config PM_PARTITION_SIZE_SETTINGS_STORAGE
-	hex "Flash space reserved for settings storage partition"
-	default 0x2000
-	help
-	  Flash space set aside for the settings storage partition.
 endif
 
 config SETTINGS_RUNTIME

--- a/subsys/settings/pm.yml
+++ b/subsys/settings/pm.yml
@@ -1,5 +1,0 @@
-#include <autoconf.h>
-
-settings_storage:
-  placement: {after: [mcuboot_storage, app]}
-  size: CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE


### PR DESCRIPTION
This commit should be squashed with the other partition manager
commits so that only the linker script patch remains of
partition manager patches.

Reduce size of downstream patches by moving as much as possible
of the partition manager (pm) functionality to the nrf repo.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>