### PR TITLE
[nrf noup] mcumgr: smp: Support enabling low latency for SMP BT

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -262,15 +262,51 @@ config MCUMGR_SMP_BT
 	help
 	  Enables handling of SMP commands received over Bluetooth.
 
+if MCUMGR_SMP_BT
+
 config MCUMGR_SMP_BT_AUTHEN
 	bool "Authenticated requirement for Bluetooth mcumgr SMP transport"
-	depends on MCUMGR_SMP_BT
 	select BT_SMP
 	default y
 	help
 	  Enables encrypted and authenticated connection requirement to
 	  Bluetooth SMP transport.
 
+config MCUMGR_SMP_BT_LOW_LATENCY
+	bool "Request low latency connection when handling SMP commands"
+	depends on SYSTEM_WORKQUEUE_PRIORITY < 0
+	help
+	  Enables support for requesting low latency connection parameter when
+	  SMP commands are handled. This option allows to speed up the command
+	  exchange process.
+	  Its recommended to enable this if SMP is used for DFU.
+
+config MCUMGR_SMP_BT_LOW_LATENCY_RESTORE_TIME
+	int "Connection latency restore time in milliseconds"
+	depends on MCUMGR_SMP_BT_LOW_LATENCY
+	default 5000
+	range 1 65535
+	help
+	  The value is a time after which connection latency is restored
+	  to default value, that is, before requesting low latency. Latency
+	  restoration time could take up to twice as long as specified time.
+	  This is because of limiting CPU time needed to support this feature.
+	  The implementation periodically checks if the low latency is still
+	  needed every MCUMGR_SMP_BT_LOW_LATENCY_RESTORE_TIME. The default
+	  latency is restored during check only if there was no SMP command
+	  exchanged in period before the check
+
+config MCUMGR_SMP_BT_LOW_LATENCY_RESTORE_RETRY_TIME
+	int "Connection latency restore retry time in milliseconds"
+	depends on MCUMGR_SMP_BT_LOW_LATENCY
+	default 1000
+	range 1 5000
+	help
+	  In case connection latency restoration fails due to an error, this
+	  option specifies the time after retry to set the default latency
+	  would be executed.
+
+endif # MCUMGR_SMP_BT
 
 config MCUMGR_SMP_SHELL
 	bool "Shell mcumgr SMP transport"


### PR DESCRIPTION
This change adds a posibility to enable low latency connection
parameters for BT when SMP commands are handled.

Support for this functionality is disabled by the default and
can be enabled by CONFIG_MCUMGR_SMP_BT_LOW_LATENCY=y option.

Jira: NCSDK-11180

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>