### PR TITLE
ci: NCS-specific CI tweaks

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -58,7 +58,7 @@ jobs:
         git config --global user.name "Your Name"
         git remote -v
         # Sauce tag checks before rebasing
-        git log --oneline --first-parent origin/${BASE_REF}..HEAD | grep -E -v "\[nrf (mergeup|fromtree|fromlist|noup)\]" && { echo 'Sauce tag missing'; exit 1; }
+        git log --oneline --first-parent origin/${BASE_REF}..HEAD | grep -E -v "\[nrf (mergeup|fromtree|fromlist|noup)\][ ]" && { echo 'Sauce tag missing or invalid, format is "[nrf <sauce-tag>] <shortlog>"'; exit 1; }
         git rebase origin/${BASE_REF}
         # debug
         git log  --pretty=oneline | head -n 10


### PR DESCRIPTION
squash! [nrf noup] ci: NCS-specific CI tweaks

A shortlog that looks like "[nrf noup]: foo: bar" has shown up in real
life and should fail this compliance test, but it doesn't. Fix that by
checking for an explicit space after the closing "]" in a sauce tag.
