### PR TITLE
[nrf fromlist] twister: add option to create shorter build paths

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2790,6 +2790,9 @@ class TestSuite(DisablePyTestCollectionMixin):
         # run integration tests only
         self.integration = False
 
+        # used during creating shorter build paths
+        self.link_dir_counter = 0
+
         self.pipeline = None
         self.version = "NA"
 
@@ -3875,6 +3878,48 @@ class TestSuite(DisablePyTestCollectionMixin):
                 break
             else:
                 logger.error(f"{log_info} - unrecognized platform - {platform}")
+
+    def create_build_dir_links(self):
+        """
+        Iterate through all no-skipped instances in suite and create links
+        for each one build directories. Those links will be passed in the next
+        steps to the CMake command.
+        """
+
+        links_dir_name = "twister_links"  # folder for all links
+        links_dir_path = os.path.join(self.outdir, links_dir_name)
+        if not os.path.exists(links_dir_path):
+            os.mkdir(links_dir_path)
+
+        for instance in self.instances.values():
+            if instance.status != "skipped":
+                self._create_build_dir_link(links_dir_path, instance)
+
+    def _create_build_dir_link(self, links_dir_path, instance):
+        """
+        Create build directory with original "long" path. Next take shorter
+        path and link them with original path - create link. At the end
+        replace build_dir to created link. This link will be passed to CMake
+        command. This action helps to limit path length which can be
+        significant during building by CMake on Windows OS.
+        """
+
+        os.makedirs(instance.build_dir)
+
+        link_name = f"test_{self.link_dir_counter}"
+        link_path = os.path.join(links_dir_path, link_name)
+
+        if os.name == "nt":  # if OS is Windows
+            command = ["mklink", "/J", f"{link_path}", f"{instance.build_dir}"]
+            subprocess.call(command, shell=True)
+        else:  # for Linux and MAC OS
+            os.symlink(instance.build_dir, link_path)
+
+        # Here symbolic link is replaced with original build directory. It will
+        # be passed to CMake command
+        instance.build_dir = link_path
+
+        self.link_dir_counter += 1
 
 
 class CoverageTool:

--- a/scripts/twister
+++ b/scripts/twister
@@ -685,6 +685,15 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
              "as 'slow' in testcase.yaml. Normally these are only built.")
 
     parser.add_argument(
+        "--short-build-path",
+        action="store_true",
+        help="Create shorter build directory paths based on symbolic links. "
+             "The shortened build path will be used by CMake for generating "
+             "the build system and executing the build. Use this option if "
+             "you experience build failures related to path length, for "
+             "example on Windows OS.")
+
+    parser.add_argument(
         "--show-footprint", action="store_true",
         help="Show footprint statistics and deltas since last release."
     )
@@ -1235,6 +1244,9 @@ def main():
         duration = time.time() - start_time
         logger.info("Completed in %d seconds" % (duration))
         return
+
+    if options.short_build_path:
+        suite.create_build_dir_links()
 
     retries = options.retry_failed + 1
     completed = 0


### PR DESCRIPTION
Commit included in this PR is cherry-picked from this PR:
https://github.com/zephyrproject-rtos/zephyr/pull/41930

**After consults with @carlescufi he accepted this cherry-picking.**
Changes in Twister proposed with this PR are crucial to make it possible to test `sdk-nrf` samples on Windows OS with nRF Connect SDK 1.9 release.

Relevant PR on `sdk-nrf` repository with changes in `west.yml` manifest in `sdk-zephyr` version:
https://github.com/nrfconnect/sdk-nrf/pull/6810

---

Originally when Twister is call by following command:
```
python scripts\twister --outdir C:\tb --ninja -p nrf5340dk_nrf5340_cpuapp -T samples/subsys/portability/cmsis_rtos_v1/timer_synchronization
```
It create following build folder: `C:\tb\nrf5340dk_nrf5340_cpuapp\samples\subsys\portability\cmsis_rtos_v1\timer_synchronization\sample.portability.cmsis_rtos_v1.timer_synchronization` which is problematic for CMake on Windows OS.

Thanks to add `--short-build-path` option to Twister command:
```
python scripts\twister --outdir C:\tb --short-build-path --ninja -p nrf5340dk_nrf5340_cpuapp -T samples/subsys/portability/cmsis_rtos_v1/timer_synchronization
```
Twister create originally build directory, but moreover it create also new directory with shorter path `C:\tb\twister_links\test_0` and next create link between those two directories. Thank to that shorter path can be pass to CMake which allow to remove problem with too long path and at once build results can be found on originally longer path.

Without this feature I am not able to use Twister during testing Zephyr's samples and tests on Windows OS.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>