### PR TITLE
[nrf fromtree] cmake: kconfig: preserved quotes for Kconfig string values

### DIFF
--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -179,12 +179,23 @@ endforeach()
 unset(EXTRA_KCONFIG_OPTIONS)
 get_cmake_property(cache_variable_names CACHE_VARIABLES)
 foreach (name ${cache_variable_names})
-  if("${name}" MATCHES "^${KCONFIG_NAMESPACE}_")
+  if("${name}" MATCHES "^CLI_${KCONFIG_NAMESPACE}_")
+    # Variable was set by user in earlier invocation, let's append to extra
+    # config unless a new value has been given.
+    string(REGEX REPLACE "^CLI_" "" org_name ${name})
+    if(NOT DEFINED ${org_name})
+      set(EXTRA_KCONFIG_OPTIONS
+        "${EXTRA_KCONFIG_OPTIONS}\n${org_name}=${${name}}"
+      )
+    endif()
+  elseif("${name}" MATCHES "^${KCONFIG_NAMESPACE}_")
     # When a cache variable starts with the 'KCONFIG_NAMESPACE' value, it is
     # assumed to be a Kconfig symbol assignment from the CMake command line.
     set(EXTRA_KCONFIG_OPTIONS
       "${EXTRA_KCONFIG_OPTIONS}\n${name}=${${name}}"
       )
+    set(CLI_${name} "${${name}}")
+    list(APPEND cli_config_list ${name})
   endif()
 endforeach()
 
@@ -318,21 +329,20 @@ add_custom_target(config-twister DEPENDS ${DOTCONFIG})
 # Remove the CLI Kconfig symbols from the namespace and
 # CMakeCache.txt. If the symbols end up in DOTCONFIG they will be
 # re-introduced to the namespace through 'import_kconfig'.
-foreach (name ${cache_variable_names})
-  if("${name}" MATCHES "^${KCONFIG_NAMESPACE}_")
-    unset(${name})
-    unset(${name} CACHE)
-  endif()
+foreach (name ${cli_config_list})
+  unset(${name})
+  unset(${name} CACHE)
 endforeach()
 
 # Import the .config file and make all settings available in CMake processing.
 import_kconfig(${KCONFIG_NAMESPACE} ${DOTCONFIG})
 
-# Re-introduce the CLI Kconfig symbols that survived
-foreach (name ${cache_variable_names})
-  if("${name}" MATCHES "^${KCONFIG_NAMESPACE}_")
-    if(DEFINED ${name})
-      set(${name} ${${name}} CACHE STRING "")
-    endif()
+# Cache the CLI Kconfig symbols that survived through Kconfig, prefixed with CLI_.
+# Remove those who might have changed compared to earlier runs, if they no longer appears.
+foreach (name ${cli_config_list})
+  if(DEFINED ${name})
+    set(CLI_${name} ${CLI_${name}} CACHE INTERNAL "")
+  else()
+    unset(CLI_${name} CACHE)
   endif()
 endforeach()


### PR DESCRIPTION
Fixes: #48950

Kconfig requires quoted strings in its configuration files, like this:
> CONFIG_A_STRING="foo bar"

But CMake requires expects that strings are without additional qoutes, and therefore qoutes are stripped when loading Kconfig config filers into CMake.

This is particular important when the string in Kconfig is a path to a file. In this case, not stripping the quotes leads to an error as the file cannot be found.

When users pass a string to Kconfig through CMake, they are expected to pass it so that qoutes are correct seen from Kconfig, that is:
> cmake -DCONFIG_A_STRING=\"foo bar\"

In CMake, those qoutes are written as-is to Kconfig extra config file, and then removed in the CMake cache.
After Kconfig processing, the Kconfig settings are read back to CMake but without quotes. Settings that was passed through the CMake cache, for example using `-D` are written back to the cache, but this time without the qoutes. This results in Kconfig errors on sub-sequent CMake runs.

Instead of writing the Kconfig value setting back to the CMake cache, introduce an internal shadow symbol in the cache prefixed with `CLI_`. This allows the CMake cache to keep the value correctly formatted for Kconfig extra config creation, while at the same time keep existing behavior for CONFIG_ symbols read from Kconfig.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>