### PR TITLE
[backport-v2.1][nrf noup] ci: use forked branches of CI repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v2.1-branch") _
 
 def pipeline = new ncs.sdk_zephyr.Main()
 


### PR DESCRIPTION
Jenkinsfile loads CI_LIB@v2.1-branch.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>