### PR TITLE
Flush stale response from previous command

### DIFF
--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -141,6 +141,10 @@ void modbus_tx_adu(struct modbus_context *ctx)
 
 int modbus_tx_wait_rx_adu(struct modbus_context *ctx)
 {
+	/* Make sure the semapore is waiting for this response */
+	if (k_sem_take(&ctx->client_wait_sem, K_NO_WAIT) == 0)
+		LOG_WRN("Spurious RX discarded");
+
 	modbus_tx_adu(ctx);
 
 	if (k_sem_take(&ctx->client_wait_sem, K_USEC(ctx->rxwait_to)) != 0) {


### PR DESCRIPTION
If the device responds after request timeout it's response will be sitting in the receive buffer when the next command is sent, which will process the earlier response as response to it's request.

Reset the semaphore when making a new request to synchronise request/response flow to the new request.