### PR TITLE
[nrf fromtree] soc: nrf53: Change logging level of anomaly 160 messag…

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -171,7 +171,7 @@ bool z_arm_on_enter_cpu_idle(void)
 
 	if (ok_to_sleep) {
 		suppress_message = false;
-	} else {
+	} else if (!suppress_message) {
 		LOG_DBG("Anomaly 160 trigger conditions detected.");
 		suppress_message = true;
 	}


### PR DESCRIPTION
…e to DEBUG

This is a follow-up to commit fe3b97a87f480eb473cd58cc1990a5845c2ca9c6.

This message should not be a warning, as it does not actually indicate that something potentially bad happened. On the contrary, it informs that conditions in which the anomaly 160 could occur were detected and the anomaly was prevented from occurring. There is no need for this message to appear in the default configuration (INFO level). In fact, the message would undesirably flood the console in some cases (like the kernel/mem_protect/stack_random test) and sometimes it would also require enlarging the stack of the idle thread (the function is called underneath k_cpu_idle()). Therefore, the logging level of this message is changed to DEBUG.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>
(cherry picked from commit 7195db01f45d8045c3dc8e982155694ee6d06928)