### PR TITLE
[nrf fromtree] net: l2: ieee802154: pkt: fix cpp build failure

### DIFF
--- a/include/zephyr/net/ieee802154_pkt.h
+++ b/include/zephyr/net/ieee802154_pkt.h
@@ -92,7 +92,7 @@ static inline void *net_pkt_cb(struct net_pkt *pkt);
 
 static inline struct net_pkt_cb_ieee802154 *net_pkt_cb_ieee802154(struct net_pkt *pkt)
 {
-	return net_pkt_cb(pkt);
+	return (struct net_pkt_cb_ieee802154 *)net_pkt_cb(pkt);
 };
 
 static inline uint8_t net_pkt_ieee802154_lqi(struct net_pkt *pkt)


### PR DESCRIPTION
CPP needs an additional cast.
    
Signed-off-by: Florian Grandel <fgrandel@code-for-humans.de>
(cherry picked from commit 718fe844c2f5c7bc3d6364913f08f9542a3ec44a)