### PR TITLE
[nrf fromtree] wifi: shell: Fix default band value

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -341,6 +341,8 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 		return -EINVAL;
 	}
 
+	params->band = WIFI_FREQ_BAND_UNKNOWN;
+
 	/* SSID */
 	params->ssid = argv[0];
 	params->ssid_length = strlen(params->ssid);


### PR DESCRIPTION
The enum is mainly to print output of band, so, the default value is 0 which means 2.4GHz, which is not correct when using it to configure like in connect.

Fix the default value to unknown i.e., no user preference. This way we can use same enum for both set and get.

Signed-off-by: Chaitanya Tata <Chaitanya.Tata@nordicsemi.no>
(cherry picked from commit 8c179870d426b18d24c8c359c52f8a30dd1bc0e5)