### PR TITLE
[nrf fromlist] tests: drivers: watchdog: disable DCACHE for nRF54H20dk

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,2 @@
+# Disable dcache
+CONFIG_DCACHE=n


### PR DESCRIPTION
Disabled data caching for nRF54H20dk in wdt_basic_api test. It caused variables stored in noinit section to be cached, resulting in reset loop.

Upstream PR #: 81438