### PR TITLE
[nrf noup] dts: nrf21540-fem default tx-en-settle-time-us=26

### DIFF
--- a/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
@@ -95,7 +95,7 @@ properties:
         This must be present to support SPI control of the FEM.
   tx-en-settle-time-us:
     type: int
-    default: 11
+    default: 26
     description: |
         Settling time in microseconds from state PG to TX.
 


### PR DESCRIPTION
The default value of the `tx-en-settle-time-us` property is set to 26 to avoid spurious emission issue.

This fix requires an MPSL that is already on the sdk-nrfxlib v3.0-branch deployed with https://github.com/nrfconnect/sdk-nrfxlib/pull/1719

The MPSL containing necessary change is not yet available on sdk-nrfxlib `main` branch. Due to this the fix will be backported to the `sdk-zephyr` main branch when necessary version of MPSL is available on `sdk-nrfxlib` main.

KRKNWK-20212