### PR TITLE
[nrf noup] boards: nordic: nrf54l15dk: Set MPSL_HFCLK_LATENCY default

### DIFF
--- a/boards/nordic/nrf54l15dk/Kconfig.defconfig
+++ b/boards/nordic/nrf54l15dk/Kconfig.defconfig
@@ -5,6 +5,11 @@
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
 DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
 
+# The 54L has a HFXO latency which is better than the default.
+config MPSL_HFCLK_LATENCY
+	int
+	default 854 if MPSL
+
 if BOARD_NRF54L15DK_NRF54L05_CPUAPP || BOARD_NRF54L15DK_NRF54L10_CPUAPP || \
 	BOARD_NRF54L15DK_NRF54L15_CPUAPP
 


### PR DESCRIPTION
This default matches the default before it got changed in https://github.com/nrfconnect/sdk-nrf/pull/22369. This ensures that the current consumption when using Bluetooth remains unchanged.

The default of 854 is slightly smaller than what is recommended by the documentation provided for MPSL_HFCLK_LATENCY. It is still likely good enough for this board and its use cases.

This noup commit can be replaced once:
* HFXO startup latency is defined in device tree: https://github.com/zephyrproject-rtos/zephyr/pull/90615
* The startup latency is configured per board and not per SoC. The startup latency is board specific as the HFXO is an SOC-external component.