### PR TITLE
[nrf fromlist] drivers: serial: nrfx_uarte: Reorder suspend

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2338,13 +2338,13 @@ static void uarte_pm_suspend(const struct device *dev)
 		wait_for_tx_stopped(dev);
 	}
 
-#ifdef CONFIG_SOC_NRF54H20_GPD
-	nrf_gpd_retain_pins_set(cfg->pcfg, true);
-#endif
+	(void)pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
 
 	nrf_uarte_disable(uarte);
 
-	(void)pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	nrf_gpd_retain_pins_set(cfg->pcfg, true);
+#endif
 }
 
 static int uarte_nrfx_pm_action(const struct device *dev, enum pm_device_action action)


### PR DESCRIPTION
To get a glitchfree UARTE suspend sequence we need to
* load the GPIO configuration for the suspend state
* disable the UARTE so the GPIO configuration is applied
* (optional) enable the GPIO retention as state should stick around

The previous sequence (optionally) locked the analog state of the GPIO so the configuration wouldn't actually get applied. Next it disabled the UART, falling back to the existing GPIO state. Next it loaded the new GPIO state, which could be different from the old GPIO state, leading to a potential transition from TX high to low to high.

Upstream PR #: 91550