### PR TITLE
[nrf noup] ci: Update CI-boot-test patterns and remove SUIT labels

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -39,6 +39,7 @@
 # Not necessary to run tests on changes to this repo.
 
 "CI-boot-test":
+  - "boards/nordic/**/*"
   - "subsys/mgmt/mcumgr/**/*"
   - "subsys/dfu/**/*"
   - "include/mgmt/mcumgr/**/*"
@@ -364,29 +365,3 @@
   - "tests/boards/nordic/**/*"
   - "tests/drivers/**/*"
   - "tests/kernel/**/*"
-
-"CI-suit-dfu-test":
-  - "subsys/mgmt/mcumgr/**/*"
-  - "include/mgmt/mcumgr/**/*"
-  - "samples/subsys/mgmt/mcumgr/smp_svr/**/*"
-  - "subsys/bluetooth/**/*"
-  - "drivers/bluetooth/**/*"
-  - "drivers/flash/**/*"
-  - "drivers/spi/**/*"
-  - "drivers/mbox/**/*"
-  - "drivers/serial/**/*"
-  - "drivers/console/**/*"
-  - "drivers/gpio/**/*"
-  - "dts/common/nordic/*"
-  - "dts/arm/nordic/nrf54h*/**/*"
-  - "dts/riscv/nordic/nrf54h*/**/*"
-  - "boards/nordic/nrf54h*/**/*"
-  - "soc/nordic/nrf54h/**/*"
-  - "include/zephyr/**/*"
-  - "subsys/logging/**/*"
-  - "subsys/tracing/**/*"
-  - "scripts/west_commands/build.py"
-  - "scripts/west_commands/flash.py"
-  - "scripts/west_commands/runners/nrfutil.py"
-  - "scripts/west_commands/runners/core.py"
-  - "scripts/west_commands/runners/nrf_common.py"


### PR DESCRIPTION
Add boards/nordic/**/* to the CI-boot-test scope and remove SUIT labels.

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>