### PR TITLE
[nrf fromtree] tests: drivers: i2s: Run I2S tests on nRF54H20

### DIFF
--- a/tests/drivers/i2s/i2s_api/testcase.yaml
+++ b/tests/drivers/i2s/i2s_api/testcase.yaml
@@ -10,6 +10,7 @@ tests:
       - mcx_n9xx_evk/mcxn947/cpu0
       - mimxrt595_evk/mimxrt595s/cm33
       - mimxrt685_evk/mimxrt685s/cm33
+      - nrf54h20dk/nrf54h20/cpuapp
   drivers.i2s.gpio_loopback:
     depends_on:
       - i2s
@@ -24,5 +25,17 @@ tests:
       - mcx_n9xx_evk/mcxn947/cpu0
       - mimxrt595_evk/mimxrt595s/cm33
       - mimxrt685_evk/mimxrt685s/cm33
+      - nrf54h20dk/nrf54h20/cpuapp
     harness_config:
       fixture: gpio_loopback
+  drivers.i2s.gpio_loopback.nrf54h:
+    depends_on: i2s
+    tags:
+      - drivers
+      - userspace
+    harness_config:
+      fixture: i2s_loopback
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/i2s/i2s_speed/testcase.yaml
+++ b/tests/drivers/i2s/i2s_speed/testcase.yaml
@@ -5,6 +5,8 @@ tests:
       - drivers
       - i2s
     filter: not CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
+    platform_exclude:
+      - nrf54h20dk/nrf54h20/cpuapp
   drivers.i2s.speed.gpio_loopback:
     depends_on:
       - i2s
@@ -13,6 +15,8 @@ tests:
       - drivers
       - i2s
     filter: CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
+    platform_exclude:
+      - nrf54h20dk/nrf54h20/cpuapp
     harness: ztest
     harness_config:
       fixture: gpio_loopback
@@ -29,3 +33,14 @@ tests:
       fixture: gpio_loopback
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf5340dk_nrf5340_cpuapp_aclk.overlay"
     platform_allow: nrf5340dk/nrf5340/cpuapp
+  drivers.i2s.speed.gpio_loopback.nrf54h:
+    depends_on: i2s
+    tags:
+      - drivers
+      - i2s
+    harness_config:
+      fixture: i2s_loopback
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Enable test execution on nRF54H20 target.


(cherry picked from commit 645fb266701c7c6755f0f829e6de5fb95e62ac95)