### PR TITLE
[nrf noup] bluetooth: host: fix compilation of auto-swap feature

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -325,7 +325,8 @@ void bt_keys_clear(struct bt_keys *keys)
 
 	LOG_DBG("%s (keys 0x%04x)", bt_addr_le_str(&keys->addr), keys->keys);
 
-	if ((keys->flags & BT_KEYS_ID_CONFLICT) != 0) {
+	if (IS_ENABLED(CONFIG_BT_ID_AUTO_SWAP_MATCHING_BONDS) &&
+	    (keys->flags & BT_KEYS_ID_CONFLICT) != 0) {
 		/* We need to check how many conflicting keys left. If there is only one conflicting
 		 * key left, we can remove the BT_KEYS_ID_CONFLICT flag from it so that Host don't
 		 * need to check and update the Resolving List whenever this is needed. The key

--- a/tests/bluetooth/host/id/mocks/adv.c
+++ b/tests/bluetooth/host/id/mocks/adv.c
@@ -15,3 +15,4 @@ DEFINE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable_legacy, struct bt_le_ext_adv *,
 DEFINE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable_ext, struct bt_le_ext_adv *, bool,
 		       const struct bt_le_ext_adv_start_param *);
 DEFINE_FAKE_VOID_FUNC(bt_le_ext_adv_foreach, bt_le_ext_adv_foreach_cb, void *);
+DEFINE_FAKE_VALUE_FUNC(struct bt_le_ext_adv *, bt_adv_lookup_by_id, uint8_t);

--- a/tests/bluetooth/host/id/mocks/adv.h
+++ b/tests/bluetooth/host/id/mocks/adv.h
@@ -18,7 +18,8 @@ typedef void (*bt_le_ext_adv_foreach_cb)(struct bt_le_ext_adv *adv, void *data);
 	FAKE(bt_le_adv_lookup_legacy)                                                              \
 	FAKE(bt_le_ext_adv_get_index)                                                              \
 	FAKE(bt_le_adv_set_enable_ext)                                                             \
-	FAKE(bt_le_ext_adv_foreach)
+	FAKE(bt_le_ext_adv_foreach)                                                                \
+	FAKE(bt_adv_lookup_by_id)
 
 DECLARE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable, struct bt_le_ext_adv *, bool);
 DECLARE_FAKE_VALUE_FUNC(struct bt_le_ext_adv *, bt_le_adv_lookup_legacy);
@@ -27,3 +28,4 @@ DECLARE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable_legacy, struct bt_le_ext_adv *
 DECLARE_FAKE_VALUE_FUNC(int, bt_le_adv_set_enable_ext, struct bt_le_ext_adv *, bool,
 			const struct bt_le_ext_adv_start_param *);
 DECLARE_FAKE_VOID_FUNC(bt_le_ext_adv_foreach, bt_le_ext_adv_foreach_cb, void *);
+DECLARE_FAKE_VALUE_FUNC(struct bt_le_ext_adv *, bt_adv_lookup_by_id, uint8_t);

--- a/tests/bluetooth/host/id/mocks/keys.c
+++ b/tests/bluetooth/host/id/mocks/keys.c
@@ -10,3 +10,4 @@
 
 DEFINE_FAKE_VALUE_FUNC(struct bt_keys *, bt_keys_find_irk, uint8_t, const bt_addr_le_t *);
 DEFINE_FAKE_VOID_FUNC(bt_keys_foreach_type, enum bt_keys_type, bt_keys_foreach_type_cb, void *);
+DEFINE_FAKE_VALUE_FUNC(struct bt_keys *, bt_keys_get_addr, uint8_t, const bt_addr_le_t *);

--- a/tests/bluetooth/host/id/mocks/keys.h
+++ b/tests/bluetooth/host/id/mocks/keys.h
@@ -15,7 +15,9 @@ typedef void (*bt_keys_foreach_type_cb)(struct bt_keys *keys, void *data);
 /* List of fakes used by this unit tester */
 #define KEYS_FFF_FAKES_LIST(FAKE)                                                                  \
 	FAKE(bt_keys_find_irk)                                                                     \
-	FAKE(bt_keys_foreach_type)
+	FAKE(bt_keys_foreach_type)                                                                 \
+	FAKE(bt_keys_get_addr)
 
 DECLARE_FAKE_VALUE_FUNC(struct bt_keys *, bt_keys_find_irk, uint8_t, const bt_addr_le_t *);
 DECLARE_FAKE_VOID_FUNC(bt_keys_foreach_type, enum bt_keys_type, bt_keys_foreach_type_cb, void *);
+DECLARE_FAKE_VALUE_FUNC(struct bt_keys *, bt_keys_get_addr, uint8_t, const bt_addr_le_t *);


### PR DESCRIPTION
This is a follow up commit for 93b8dd96508ddc5b86ea2f34ea57501fce5311b2 where auto-swap feature was added.

This commit fixes compilation of Host without the feature enabled.