### PR TITLE
Enable SOC_NRF54H20_CPURAD_ENABLE and SOC_NRF53_CPUNET_ENABLE by defa…

### DIFF
--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -208,7 +208,7 @@ config SOC_NRF53_CPUNET_MGMT
 
 config SOC_NRF53_CPUNET_ENABLE
 	bool "NRF53 Network MCU is enabled at boot time"
-	default y if NRF_802154_SER_HOST
+	default y if NRF_802154_SER_HOST || BT
 	select SOC_NRF53_CPUNET_MGMT
 	help
 	  This option enables releasing the Network 'force off' signal, which

--- a/soc/nordic/nrf54h/Kconfig
+++ b/soc/nordic/nrf54h/Kconfig
@@ -80,7 +80,7 @@ config SOC_NRF54H20_TDD_ENABLE
 
 config SOC_NRF54H20_CPURAD_ENABLE
 	bool "Boot the nRF54H20 Radio core"
-	default y if NRF_802154_SER_HOST
+	default y if NRF_802154_SER_HOST || BT
 	depends on SOC_NRF54H20_CPUAPP
 	select NRF_IRONSIDE_CPUCONF_SERVICE
 	select SOC_LATE_INIT_HOOK


### PR DESCRIPTION
…ult for BLE samples

At the moment these configs should be selected explicitly for each sample. Apply them by default as these configs enable the clock for radio (network) core during application boot time and requests power for radio (network) core. Once powered, radio (network) core begins executing instructions.