### PR TITLE
[nrf fromtree] tests: fs: littlefs: Fix nRF54L15-based dtc overlay files

### DIFF
--- a/tests/subsys/fs/littlefs/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/subsys/fs/littlefs/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &slot0_ns_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &slot1_ns_partition;
 
 &cpuapp_rram {
 	partitions {
@@ -15,9 +13,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		small_partition: partition@67000 {
+		small_partition: partition@b6000 {
 			label = "small";
-			reg = <0x00067000 0x00010000>;
+			reg = <0x000b6000 0x00010000>;
 		};
 	};
 };

--- a/tests/subsys/fs/littlefs/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/subsys/fs/littlefs/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &slot0_ns_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &slot1_ns_partition;
 
 &cpuapp_rram {
 	partitions {
@@ -15,9 +13,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		small_partition: partition@67000 {
+		small_partition: partition@b6000 {
 			label = "small";
-			reg = <0x00067000 0x00010000>;
+			reg = <0x000b6000 0x00010000>;
 		};
 	};
 };

--- a/tests/subsys/fs/littlefs/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/subsys/fs/littlefs/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &slot0_ns_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &slot1_ns_partition;
 
 &cpuapp_rram {
 	partitions {
@@ -14,9 +12,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		small_partition: partition@67000 {
+		small_partition: partition@b6000 {
 			label = "small";
-			reg = <0x00067000 0x00010000>;
+			reg = <0x000b6000 0x00010000>;
 		};
 	};
 };

--- a/tests/subsys/fs/littlefs/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/tests/subsys/fs/littlefs/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &slot0_ns_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &slot1_ns_partition;
 
 &cpuapp_rram {
 	partitions {
@@ -14,9 +12,9 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		small_partition: partition@67000 {
+		small_partition: partition@b6000 {
 			label = "small";
-			reg = <0x00067000 0x00010000>;
+			reg = <0x000b6000 0x00010000>;
 		};
 	};
 };


### PR DESCRIPTION
Fixes these files to no longer delete non-secure partitions as they are not present, and updates the offset of the area to use


(cherry picked from commit 3d11c84cfbcefef6ba0c341ad77d90a3e9daed18)