### PR TITLE
[nrf noup] samples: bluetooth: Add support for nRF54lm20a to hci_uart

### DIFF
--- a/samples/bluetooth/hci_uart/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/bluetooth/hci_uart/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&uart20 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <1000000>;
+	status = "okay";
+	hw-flow-control;
+};

--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -8,10 +8,14 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     tags:
       - uart
       - bluetooth


### PR DESCRIPTION
Add support for nRF54lm20a to the hci_uart sample.