### PR TITLE
[nrf noup] Bluetooth: BAP: Add target latency and phy to codec_cfg

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -550,6 +550,10 @@ enum bt_audio_metadata_type {
 		/* Use HCI data path as default, can be overwritten by application */              \
 		.path_id = BT_ISO_DATA_PATH_HCI,                                                   \
 		.ctlr_transcode = false,                                                           \
+		COND_CODE_1(IS_ENABLED(CONFIG_BT_BAP_UNICAST),                                     \
+			    (.target_latency = BT_AUDIO_CODEC_CFG_TARGET_LATENCY_BALANCED,         \
+			     .target_phy = BT_AUDIO_CODEC_CFG_TARGET_PHY_2M,),                     \
+			    ())                                                                    \
 		.id = _id,                                                                         \
 		.cid = _cid,                                                                       \
 		.vid = _vid,                                                                       \
@@ -714,6 +718,39 @@ struct bt_audio_codec_cap {
 #endif /* CONFIG_BT_AUDIO_CODEC_CAP_MAX_METADATA_SIZE */
 };
 
+/**
+ * @brief Codec configuration target latency
+ *
+ * Set by the BAP Unicast Client to provide context for the BAP Unicast Server for the server to
+ * set its QoS preferences.
+ */
+enum bt_audio_codec_cfg_target_latency {
+	/** Target low latency */
+	BT_AUDIO_CODEC_CFG_TARGET_LATENCY_LOW = 0x01,
+
+	/** Target balanced latency */
+	BT_AUDIO_CODEC_CFG_TARGET_LATENCY_BALANCED = 0x02,
+
+	/** Target high latency */
+	BT_AUDIO_CODEC_CFG_TARGET_LATENCY_HIGH = 0x03,
+};
+
+/**
+ * @brief Codec configuration target PHY
+ *
+ * The target PHY to achieve the target latency (@ref bt_audio_codec_cfg_target_latency).
+ */
+enum bt_audio_codec_cfg_target_phy {
+	/** LE 1M PHY */
+	BT_AUDIO_CODEC_CFG_TARGET_PHY_1M = 0x01,
+
+	/** LE 2M PHY */
+	BT_AUDIO_CODEC_CFG_TARGET_PHY_2M = 0x02,
+
+	/** LE Coded PHY */
+	BT_AUDIO_CODEC_CFG_TARGET_PHY_CODED = 0x03,
+};
+
 /** @brief Codec specific configuration structure. */
 struct bt_audio_codec_cfg {
 	/** Data path ID
@@ -728,6 +765,18 @@ struct bt_audio_codec_cfg {
 	 * BT_HCI_CODING_FORMAT_TRANSPARENT if false, else uses the @ref bt_audio_codec_cfg.id.
 	 */
 	bool ctlr_transcode;
+#if defined(CONFIG_BT_BAP_UNICAST)
+	/** Target latency
+	 *
+	 * Unused for broadcast streams.
+	 */
+	enum bt_audio_codec_cfg_target_latency target_latency;
+	/** Target PHY
+	 *
+	 * Unused for broadcast streams.
+	 */
+	enum bt_audio_codec_cfg_target_phy target_phy;
+#endif /* CONFIG_BT_BAP_UNICAST */
 	/** Codec ID */
 	uint8_t  id;
 	/** Codec Company ID */

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1487,8 +1487,9 @@ static void ascs_cp_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	LOG_DBG("attr %p value 0x%04x", attr, value);
 }
 
-static int ascs_ep_set_codec(struct bt_bap_ep *ep, uint8_t id, uint16_t cid, uint16_t vid,
-			     uint8_t *cc, uint8_t len, struct bt_bap_ascs_rsp *rsp)
+static int ascs_ep_set_codec(struct bt_bap_ep *ep, uint8_t target_latency, uint8_t target_phy,
+			     uint8_t id, uint16_t cid, uint16_t vid, const uint8_t *cc, uint8_t len,
+			     struct bt_bap_ascs_rsp *rsp)
 {
 	const struct bt_audio_codec_cap *codec_cap;
 	struct bt_audio_codec_cfg *codec_cfg;
@@ -1520,6 +1521,8 @@ static int ascs_ep_set_codec(struct bt_bap_ep *ep, uint8_t id, uint16_t cid, uin
 		return -ENOENT;
 	}
 
+	codec_cfg->target_latency = target_latency;
+	codec_cfg->target_phy = target_phy;
 	codec_cfg->id = id;
 	codec_cfg->cid = cid;
 	codec_cfg->vid = vid;
@@ -1588,10 +1591,10 @@ static int ase_config(struct bt_ascs_ase *ase, const struct bt_ascs_config *cfg)
 	 */
 	(void)memcpy(&codec_cfg, &ase->ep.codec_cfg, sizeof(codec_cfg));
 
-	err = ascs_ep_set_codec(&ase->ep, cfg->codec.id, sys_le16_to_cpu(cfg->codec.cid),
-				sys_le16_to_cpu(cfg->codec.vid), (uint8_t *)cfg->cc, cfg->cc_len,
-				&rsp);
-	if (err) {
+	err = ascs_ep_set_codec(&ase->ep, cfg->latency, cfg->phy, cfg->codec.id,
+				sys_le16_to_cpu(cfg->codec.cid), sys_le16_to_cpu(cfg->codec.vid),
+				(const uint8_t *)cfg->cc, cfg->cc_len, &rsp);
+	if (err != 0) {
 		ascs_app_rsp_warn_valid(&rsp);
 		(void)memcpy(&ase->ep.codec_cfg, &codec_cfg, sizeof(codec_cfg));
 		ascs_cp_rsp_add(ASE_ID(ase), rsp.code, rsp.reason);

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1936,8 +1936,8 @@ static int unicast_client_ep_config(struct bt_bap_ep *ep, struct net_buf_simple 
 
 	req = net_buf_simple_add(buf, sizeof(*req));
 	req->ase = ep->status.id;
-	req->latency = 0x02; /* TODO: Select target latency based on additional input? */
-	req->phy = 0x02;     /* TODO: Select target PHY based on additional input? */
+	req->latency = codec_cfg->target_latency;
+	req->phy = codec_cfg->target_phy;
 	req->codec.id = codec_cfg->id;
 	req->codec.cid = codec_cfg->cid;
 	req->codec.vid = codec_cfg->vid;


### PR DESCRIPTION
The codec configuration operation for unicast (ASCS) contain both a target PHY and a target latency value that was previously just hardcoded by the client and unavailable by the server.

This commit adds them to the bt_audio_codec_cfg struct so that applications can both set and get these values.

The default values used by BT_AUDIO_CODEC_CFG use the same values as the client would previously set.


(cherry picked from commit 8788f8ba260d60e7f0b003324da93d3e29757ae2)