### PR TITLE
[nrf fromlist] tests: drivers: spi: spi_loopback: skip timing test wh…

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -291,6 +291,9 @@ ZTEST(spi_loopback, test_spi_complete_multiple)
 /* same as the test_spi_complete_multiple test, but seeing if there is any unreasonable latency */
 ZTEST(spi_loopback, test_spi_complete_multiple_timed)
 {
+	/* Do not check timing when coverage is enabled */
+	Z_TEST_SKIP_IFDEF(CONFIG_COVERAGE);
+
 	struct spi_dt_spec *spec = loopback_specs[spec_idx];
 	const struct spi_buf_set tx = spi_loopback_setup_xfer(tx_bufs_pool, 2,
 							      buffer_tx, BUF_SIZE,


### PR DESCRIPTION
…en COVERAGE

Skip checking timing expectation when COVERAGE is used. Coverage mode affect timing - making code slower,
as additional operations are needed to gather coverage stats.

Upstream PR #: 94927