### PR TITLE
[nrf noup] ci: prevent PRs from installing python pkgs

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,6 +1,8 @@
 name: Manifest
 on:
   pull_request_target:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -16,7 +18,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: zephyrproject/zephyr
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -31,6 +33,14 @@ jobs:
         run: |
           cd zephyrproject/zephyr
           pip install -r scripts/requirements-actions.txt --require-hashes
+
+      - name: Checkout the code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: zephyrproject/zephyr
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: west setup
         env:


### PR DESCRIPTION
pip install requirements-actions.txt from base branch instead of untrusted PR

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>
