### PR TITLE
[nrf fromlist] tests: drivers: clock_control_api: fix Kconfig logic

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/Kconfig
+++ b/tests/drivers/clock_control/clock_control_api/Kconfig
@@ -3,7 +3,7 @@
 
 config TEST_NRF_HF_STARTUP_TIME_US
 	int "Delay required for HF clock startup."
-	default 3000 if CONFIG_SOC_SERIES_NRF91X
+	default 3000 if SOC_SERIES_NRF91X
 	default 500
 	depends on SOC_FAMILY_NORDIC_NRF
 	help


### PR DESCRIPTION
Kconfig was using symbol with redundant CONFIG prefix.

Upstream PR #: 95496