### PR TITLE
[nrf fromtree] drivers: misc: nordic_vpr_launcher: add DMA secure att…

### DIFF
--- a/dts/bindings/riscv/nordic,nrf-vpr-coprocessor.yaml
+++ b/dts/bindings/riscv/nordic,nrf-vpr-coprocessor.yaml
@@ -30,3 +30,8 @@ properties:
     type: boolean
     description: |
       Enables setting VPR core's secure attribute to secure.
+
+  enable-dma-secure:
+    type: boolean
+    description: |
+      Enables setting VPR core's DMA secure attribute to secure.


### PR DESCRIPTION
…ribute support

Extend vpr_launcher and device tree bindings to support configuring the DMA secure attribute.


(cherry picked from commit 8053d23c3985cc14c1448ebae95579273e0442f6)