### PR TITLE
[nrf noup] ci: add reopen for manifest-pr action

### DIFF
--- a/.github/workflows/manifest-PR.yml
+++ b/.github/workflows/manifest-PR.yml
@@ -1,7 +1,7 @@
 name: handle manifest PR
 on:
   pull_request_target:
-    types: [opened, synchronize, closed]
+    types: [opened, synchronize, closed, reopened]
     branches:
       - main
 


### PR DESCRIPTION
Previously reopening of PR did not reopen manifest PR. This commit will enable reopening of manifest PR in such case.
manifest-pr-skip