### PR TITLE
[nrf fromlist] arch: Allow to specify memory for S2RAM resume

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -343,17 +343,24 @@ zephyr_udc0: &usbhs {
 
 /* Trim this RAM block for making room on all run-time common S2RAM cpu context. */
 &cpuapp_ram0 {
-	reg = <0x22000000 (DT_SIZE_K(32) - 48)>;
-	ranges = <0x0 0x22000000 (0x8000 - 0x30)>;
+	reg = <0x22000000 (DT_SIZE_K(32) - 52)>;
+	ranges = <0x0 0x22000000 (0x8000 - 0x34)>;
 };
 
 / {
 	soc {
 		/* temporary stack for S2RAM resume logic */
-		pm_s2ram_stack: cpuapp_s2ram_stack@22007fd0  {
+		pm_s2ram_stack: cpuapp_s2ram_stack@22007fcc  {
 			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0x22007fd0 16>;
+			reg = <0x22007fcc 16>;
 			zephyr,memory-region = "pm_s2ram_stack";
+		};
+
+		/* run-time common mcuboot S2RAM support section */
+		mcuboot_s2ram: cpuapp_s2ram@22007fdc  {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x22007fdc 4>;
+			zephyr,memory-region = "mcuboot_s2ram_context";
 		};
 
 		/* run-time common S2RAM cpu context RAM */

--- a/soc/nordic/nrf54h/pm_s2ram.c
+++ b/soc/nordic/nrf54h/pm_s2ram.c
@@ -219,10 +219,24 @@ static void fpu_restore(_fpu_context_t *backup)
 #endif /* !defined(CONFIG_FPU_SHARING) */
 #endif /* defined(CONFIG_FPU) */
 
+#if DT_NODE_EXISTS(DT_NODELABEL(mcuboot_s2ram)) &&\
+	DT_NODE_HAS_COMPAT(DT_NODELABEL(mcuboot_s2ram), zephyr_memory_region)
+/* Linker section name is given by `zephyr,memory-region` property of
+ * `zephyr,memory-region` compatible DT node with nodelabel `mcuboot_s2ram`.
+ */
+__attribute__((section(DT_PROP(DT_NODELABEL(mcuboot_s2ram), zephyr_memory_region))))
+volatile struct mcuboot_resume_s _mcuboot_resume;
+
+#define SET_MCUBOOT_RESUME_MAGIC() _mcuboot_resume.magic = MCUBOOT_S2RAM_RESUME_MAGIC
+#else
+#define SET_MCUBOOT_RESUME_MAGIC()
+#endif
+
 int soc_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
 {
 	int ret;
 
+	SET_MCUBOOT_RESUME_MAGIC();
 	scb_save(&backup_data.scb_context);
 #if defined(CONFIG_FPU)
 #if !defined(CONFIG_FPU_SHARING)

--- a/soc/nordic/nrf54h/pm_s2ram.h
+++ b/soc/nordic/nrf54h/pm_s2ram.h
@@ -10,6 +10,12 @@
 #ifndef _ZEPHYR_SOC_ARM_NORDIC_NRF_PM_S2RAM_H_
 #define _ZEPHYR_SOC_ARM_NORDIC_NRF_PM_S2RAM_H_
 
+#define MCUBOOT_S2RAM_RESUME_MAGIC 0x75832419
+
+struct mcuboot_resume_s {
+	uint32_t magic; /* magic value to identify valid structure */
+};
+
 /**
  * @brief Save CPU state on suspend
  *


### PR DESCRIPTION
If the area, dedicated for the interrupt stack is not available, allow to specify a memory region that will be used as the stack for the S2RAM resume logic.

Upstream PR #: 95914

manifest-pr-skip

ref.: NCSDK-35410