### PR TITLE
[nrf noup] scripts: requirements: Use gitlint-core for loose requirements

### DIFF
--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -3,7 +3,7 @@
 # used by ci/check_compliance
 # zephyr-keep-sorted-start
 clang-format>=15.0.0
-gitlint
+gitlint-core
 junitparser>=4.0.1
 lxml>=5.3.0
 pykwalify

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -7,7 +7,7 @@ anytree
 gitpython>=3.1.41
 
 # helper for developers - check git commit messages
-gitlint
+gitlint-core
 
 # helper for developers
 junit2html


### PR DESCRIPTION
Gitlint-core has loose requirements and not conflicting with scancode-toolkit.