### PR TITLE
[nrf fromlist] tests: ram_context_for_isr: pick IRQ number for nRF54L

### DIFF
--- a/tests/application_development/ram_context_for_isr/Kconfig
+++ b/tests/application_development/ram_context_for_isr/Kconfig
@@ -12,6 +12,7 @@ config TEST_IRQ_NUM
 	default 18 if SOC_SERIES_STM32C0X
 	default 1 if (SOC_SERIES_NPCX9 || SOC_SERIES_NPCX7 || SOC_SERIES_NPCK3)
 	default 29 if SOC_K32L2B31A
+	default 28 if SOC_SERIES_NRF54LX
 	default 0
 	help
 	  IRQ number to use for testing purposes. This should be an


### PR DESCRIPTION
Picked IRQ number available on all platforms.