### PR TITLE
[nrf fromtree] drivers: i2c: Extend i2c testing on nrf54h20 PPR

### DIFF
--- a/samples/drivers/i2c/rtio_loopback/boards/nrf54h20dk_nrf54h20_cpuppr.conf
+++ b/samples/drivers/i2c/rtio_loopback/boards/nrf54h20dk_nrf54h20_cpuppr.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C_NRFX_TWIS_BUF_SIZE=256

--- a/samples/drivers/i2c/rtio_loopback/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/samples/drivers/i2c/rtio_loopback/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SDA = P2.8 and P2.9
+ * SCL = P1.2 and P1.3
+ */
+
+/ {
+	aliases {
+		i2c-controller = &i2c130;
+		i2c-controller-target = &i2c131;
+	};
+};
+
+&pinctrl {
+	i2c130_default: i2c130_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c130_sleep: i2c130_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default: i2c131_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep: i2c131_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c130 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c130_default>;
+	pinctrl-1 = <&i2c130_sleep>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+	status = "okay";
+};
+
+&i2c131 {
+	compatible = "nordic,nrf-twis";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c131_default>;
+	pinctrl-1 = <&i2c131_sleep>;
+	pinctrl-names = "default", "sleep";
+	status = "okay";
+};

--- a/samples/drivers/i2c/rtio_loopback/sample.yaml
+++ b/samples/drivers/i2c/rtio_loopback/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - b_u585i_iot02a
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nucleo_f401re

--- a/samples/drivers/i2c/rtio_loopback/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/i2c/rtio_loopback/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c130 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};
+
+&i2c131 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};

--- a/samples/drivers/i2c/rtio_loopback/sysbuild/vpr_launcher/prj.conf
+++ b/samples/drivers/i2c/rtio_loopback/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,3 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+# nothing here

--- a/tests/drivers/i2c/i2c_nrfx_twim/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/i2c/i2c_nrfx_twim/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SDA = P2.8 and P2.9
+ * SCL = P1.2 and P1.3
+ */
+
+/ {
+	aliases {
+		i2c-controller = &i2c130;
+		i2c-controller-target = &i2c131;
+	};
+};
+
+&pinctrl {
+	i2c130_default: i2c130_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c130_sleep: i2c130_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default: i2c131_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep: i2c131_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c130 {
+	compatible = "nordic,nrf-twim";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c130_default>;
+	pinctrl-1 = <&i2c130_sleep>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+	status = "okay";
+};
+
+&i2c131 {
+	compatible = "nordic,nrf-twis";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c131_default>;
+	pinctrl-1 = <&i2c131_sleep>;
+	pinctrl-names = "default", "sleep";
+	status = "okay";
+};

--- a/tests/drivers/i2c/i2c_nrfx_twim/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_nrfx_twim/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c130 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};
+
+&i2c131 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};

--- a/tests/drivers/i2c/i2c_nrfx_twim/sysbuild/vpr_launcher/prj.conf
+++ b/tests/drivers/i2c/i2c_nrfx_twim/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,3 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+# nothing here

--- a/tests/drivers/i2c/i2c_nrfx_twim/testcase.yaml
+++ b/tests/drivers/i2c/i2c_nrfx_twim/testcase.yaml
@@ -12,6 +12,7 @@ tests:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp

--- a/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuppr.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuppr.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C_NRFX_TWIS_BUF_SIZE=256
+CONFIG_GPIO=y

--- a/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SDA = P2.8 and P2.9
+ * SCL = P1.2 and P1.3
+ */
+
+/ {
+	zephyr,user {
+		sda0-gpios = <&gpio2 8 0>;
+		scl0-gpios = <&gpio1 2 0>;
+		sda1-gpios = <&gpio2 9 0>;
+		scl1-gpios = <&gpio1 3 0>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&pinctrl {
+	i2c130_default: i2c130_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c130_sleep: i2c130_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default: i2c131_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep: i2c131_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c130 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c130_default>;
+	pinctrl-1 = <&i2c130_sleep>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		address-width = <8>;
+		size = <256>;
+	};
+};
+
+&i2c131 {
+	compatible = "nordic,nrf-twis";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c131_default>;
+	pinctrl-1 = <&i2c131_sleep>;
+	pinctrl-names = "default", "sleep";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		address-width = <8>;
+		size = <256>;
+	};
+};
+
+&gpiote130 {
+	status = "okay";
+};

--- a/tests/drivers/i2c/i2c_target_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_target_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c130 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};
+
+&i2c131 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};

--- a/tests/drivers/i2c/i2c_target_api/sysbuild/vpr_launcher/prj.conf
+++ b/tests/drivers/i2c/i2c_target_api/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,3 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+# nothing here

--- a/tests/drivers/i2c/i2c_target_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_target_api/testcase.yaml
@@ -65,6 +65,7 @@ tests:
       - max32690evkit/max32690/m4
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - ophelia4ev/nrf54l15/cpuapp


### PR DESCRIPTION
Enable all possible i2c tests on CPUPPR


(cherry picked from commit b60633b3a6189a83902209f679ff666f95fded0b)