### PR TITLE
[nrf noup] soc: nordic: Support TF-M for poweroff

### DIFF
--- a/soc/nordic/common/poweroff.c
+++ b/soc/nordic/common/poweroff.c
@@ -7,7 +7,9 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/drivers/retained_mem/nrf_retained_mem.h>
 
-#if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
+#if defined(CONFIG_TFM_NRF_SYSTEM_OFF_SERVICE)
+#include "tfm_platform_api.h"
+#elif defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
 #include <hal/nrf_power.h>
 #elif defined(CONFIG_SOC_SERIES_NRF54HX)
 #include <power.h>
@@ -30,6 +32,10 @@
 
 void z_sys_poweroff(void)
 {
+#if defined(CONFIG_TFM_NRF_SYSTEM_OFF_SERVICE)
+	tfm_platform_system_off();
+#else
+
 #if defined(CONFIG_HAS_NORDIC_RAM_CTRL)
 	uint8_t *ram_start;
 	size_t ram_size;
@@ -77,6 +83,8 @@ void z_sys_poweroff(void)
 #else
 	nrf_regulators_system_off(NRF_REGULATORS);
 #endif
+
+#endif /* CONFIG_TFM_NRF_SYSTEM_OFF_SERVICE */
 
 	CODE_UNREACHABLE;
 }


### PR DESCRIPTION
    Enable going to system off when the TF-M API is available. This
    calls the relevant TF-M platform API to enter system off mode using
    TF-M. This is a noup because the TF-M service for system off is
    currently located in sdk-nrf only.

    This is meant to be a short lived commit, work is already ongoing
    to upstream an official TF-M system off solution that can be be
    added to upstream Zephyr.
