### PR TITLE
[nrf fromtree] scripts: compliance: Add basic cmake style checks

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1793,6 +1793,34 @@ def filter_py(root, fnames):
                              mime=True) == "text/x-python")]
 
 
+class CMakeStyle(ComplianceTest):
+    """
+    Checks cmake style added/modified files
+    """
+    name = "CMakeStyle"
+    doc = "See https://docs.zephyrproject.org/latest/contribute/style/cmake.html for more details."
+
+    def run(self):
+        # Loop through added/modified files
+        for fname in get_files(filter="d"):
+            if fname.endswith(".cmake") or fname == "CMakeLists.txt":
+                self.check_style(fname)
+
+    def check_style(self, fname):
+        SPACE_BEFORE_OPEN_BRACKETS_CHECK = re.compile(r"^\s*if\s+\(")
+        TAB_INDENTATION_CHECK = re.compile(r"^\t+")
+
+        with open(fname, encoding="utf-8") as f:
+            for line_num, line in enumerate(f.readlines(), start=1):
+                if TAB_INDENTATION_CHECK.match(line):
+                    self.fmtd_failure("error", "CMakeStyle", fname, line_num,
+                                      "Use spaces instead of tabs for indentation")
+
+                if SPACE_BEFORE_OPEN_BRACKETS_CHECK.match(line):
+                    self.fmtd_failure("error", "CMakeStyle", fname, line_num,
+                                      "Remove space before '(' in if() statements")
+
+
 class Identity(ComplianceTest):
     """
     Checks if Emails of author and signed-off messages are consistent.


### PR DESCRIPTION
It is very common to see a comment stating that the "No Space Before Opening Brackets" style guide is not followed. To avoid putting this burdon on reviewers, let the compliance check catch this instead.

Checking for tab indentation was also very simple, so also added this.

Running this check on all files finds many violations:
 - Space before opening brackets: 141 violations
 - Tab indentation: 420 violations

Fixing these will not be done as part of this PR. Adding the check will prevent us from adding new violations.


(cherry picked from commit e9abaf435ba93c31112bba32861ec8c0a22b9574)