### PR TITLE
[nrf noup] scripts: ci: check_compliance: Check Kconfigs for enable

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1232,6 +1232,7 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
                           ":!/doc/nrf/releases_and_maturity",
                           ":!/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst",
                           ":!/doc/nrf/app_dev/device_guides/nrf70/wifi_advanced_security_modes.rst",
+                          ":!/doc/nrf-bm/release_notes",
                           cwd=GIT_TOP)
 
         # splitlines() supports various line terminators


### PR DESCRIPTION
Allows checking sdk-nrf for Kconfig prompts that start with "Enable" as these should not be allowed