### PR TITLE
[nrf fromtree] tests: boards: nrf: add rram_throttling test

### DIFF
--- a/tests/boards/nrf/rram_throttling/testcase.yaml
+++ b/tests/boards/nrf/rram_throttling/testcase.yaml
@@ -13,3 +13,5 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Verifies that the throttling is working for boards that enable CONFIG_SOC_FLASH_NRF_THROTTLING

(cherry picked from commit ac3e7cb6da6cca81693bf06d795f83b7f937b32a)