### PR TITLE
[nrf fromlist] dts: vendor: nordic: fix nrf54lm20a/*[/ns] sram size

### DIFF
--- a/dts/vendor/nordic/nrf54lm20a.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a.dtsi
@@ -109,10 +109,10 @@
 		/* FLPR/VPR is not used with TF-M so NS can use its memory */
 		cpuapp_sram: memory@20000000 {
 			compatible = "mmio-sram";
-			reg = <0x20000000 0x2007FE40>;
+			reg = <0x20000000 0x7fe40>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20000000 0x2007FE40>;
+			ranges = <0x0 0x20000000 0x7fe40>;
 		};
 #else
 		cpuapp_sram: memory@20000000 {


### PR DESCRIPTION
reg attribute is supposed to hold start address and size instead of start address and end address. This caused a crash in malloc_prepare().

Upstream PR #: 103417

manifest-pr-skip