### PR TITLE
[nrf fromtree] boards: nordic: fix flash_load_offset calculation

### DIFF
--- a/boards/nordic/nrf9280pdk/Kconfig.defconfig
+++ b/boards/nordic/nrf9280pdk/Kconfig.defconfig
@@ -14,10 +14,13 @@ endif # BOARD_NRF9280PDK_NRF9280_CPUPPR
 
 if BOARD_NRF9280PDK_NRF9280_CPUAPP
 
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config ROM_START_OFFSET
 	default 0x800 if BOOTLOADER_MCUBOOT
 
 config FLASH_LOAD_OFFSET
-	default $(dt_nodelabel_reg_addr_hex,cpuapp_boot_partition) if !USE_DT_CODE_PARTITION
+	default $(sub_hex, $(dt_nodelabel_reg_addr_hex,cpuapp_boot_partition), \
+		$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))) if !USE_DT_CODE_PARTITION
 
 endif # BOARD_NRF9280PDK_NRF9280_CPUAPP


### PR DESCRIPTION
- dt_nodelabel_reg_addr_hex returns an absolute address. To obtain the partition offset, subtract the parent node’s origin.

Upstream PR#: 103764