### PR TITLE
Revert "[nrf noup] ble: Adding missing AES config for BT_CRYPTO"

### DIFF
--- a/subsys/bluetooth/crypto/Kconfig
+++ b/subsys/bluetooth/crypto/Kconfig
@@ -7,7 +7,6 @@ config BT_CRYPTO
 	select PSA_WANT_KEY_TYPE_AES
 	select PSA_WANT_ALG_CMAC
 	select PSA_WANT_ALG_ECB_NO_PADDING
-	imply MBEDTLS_CIPHER_AES_ENABLED if !BUILD_WITH_TFM
 	imply MBEDTLS_AES_ROM_TABLES if MBEDTLS_PSA_CRYPTO_C
 	help
 	  This option enables the Bluetooth Cryptographic Toolbox.


### PR DESCRIPTION
nrf-squash! [nrf noup] ble: Adding missing AES config for BT_CRYPTO

This reverts commit e7b3779b58584ab4c9badbafda32b2c21d6fc50a.

manifest-pr-skip