### PR TITLE
Revert "[nrf noup] mbedtls: Enable PSA_WANT_GENERATE_RANDOM for PSA RNG"

### DIFF
--- a/drivers/entropy/Kconfig.psa_crypto
+++ b/drivers/entropy/Kconfig.psa_crypto
@@ -7,7 +7,6 @@ config ENTROPY_PSA_CRYPTO_RNG
 	bool "PSA Crypto Random source Entropy driver"
 	depends on DT_HAS_ZEPHYR_PSA_CRYPTO_RNG_ENABLED
 	select ENTROPY_HAS_DRIVER
-	select PSA_WANT_GENERATE_RANDOM
 	default y
 	help
 	  Enable the PSA Crypto source Entropy driver.


### PR DESCRIPTION
nrf-squash! [nrf noup] mbedtls: Enable PSA_WANT_GENERATE_RANDOM for PSA RNG

This reverts commit b3f3a15be778db47df9ff62c91e2c2511be24345.

manifest-pr-skip