### PR TITLE
[nrf fromlist] dts: nordic: nrf54l15: Remove cpuflpr resource reserva…

### DIFF
--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp.dts
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp.dts
@@ -20,11 +20,5 @@
 	};
 };
 
-/* FLPR not supported yet, give all SRAM and RRAM to the APP core */
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(192)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(192)>;
-};
-
 /* Include default memory partition configuration file */
 #include <vendor/nordic/nrf54l10_cpuapp_partition.dtsi>

--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuflpr.dts
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuflpr.dts
@@ -6,7 +6,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf54l15_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54l15_cpuflpr.dtsi>
 #include "bl54l15_dvk_common.dtsi"
 
 / {
@@ -20,13 +20,6 @@
 		zephyr,flash = &cpuflpr_rram;
 		zephyr,sram = &cpuflpr_sram;
 	};
-};
-
-&cpuflpr_sram {
-	status = "okay";
-	/* size must be increased due to booting from SRAM */
-	reg = <0x20028000 DT_SIZE_K(96)>;
-	ranges = <0x0 0x20028000 0x18000>;
 };
 
 &cpuflpr_rram {

--- a/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuflpr.dts
+++ b/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuflpr.dts
@@ -6,7 +6,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf54l15_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54l15_cpuflpr.dtsi>
 #include "bl54l15u_dvk_common.dtsi"
 
 / {
@@ -20,13 +20,6 @@
 		zephyr,flash = &cpuflpr_rram;
 		zephyr,sram = &cpuflpr_sram;
 	};
-};
-
-&cpuflpr_sram {
-	status = "okay";
-	/* size must be increased due to booting from SRAM */
-	reg = <0x20028000 DT_SIZE_K(96)>;
-	ranges = <0x0 0x20028000 0x18000>;
 };
 
 &cpuflpr_rram {

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp.dts
@@ -19,11 +19,5 @@
 	};
 };
 
-/* FLPR not supported yet, give all SRAM and RRAM to the APP core */
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(96)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(96)>;
-};
-
 /* Include default memory partition configuration file */
 #include <nordic/nrf54l05_partition.dtsi>

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp.dts
@@ -19,11 +19,5 @@
 	};
 };
 
-/* FLPR not supported yet, give all SRAM and RRAM to the APP core */
-&cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(192)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(192)>;
-};
-
 /* Include default memory partition configuration file */
 #include <vendor/nordic/nrf54l10_cpuapp_partition.dtsi>

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
@@ -5,10 +5,8 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf54l15_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54l15_cpuflpr.dtsi>
 #include "nrf54l15dk_common.dtsi"
-
-/delete-node/ &cpuflpr_sram;
 
 / {
 	model = "Nordic nRF54L15 DK nRF54L15 FLPR MCU";
@@ -20,16 +18,6 @@
 		zephyr,code-partition = &cpuflpr_code_partition;
 		zephyr,flash = &cpuflpr_rram;
 		zephyr,sram = &cpuflpr_sram;
-	};
-
-	cpuflpr_sram: memory@20028000 {
-		compatible = "mmio-sram";
-		/* Size must be increased due to booting from SRAM */
-		reg = <0x20028000 DT_SIZE_K(96)>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges = <0x0 0x20028000 0x18000>;
-		status = "okay";
 	};
 };
 

--- a/boards/nordic/nrf54l15tag/nrf54l15tag_cpuflpr_common.dtsi
+++ b/boards/nordic/nrf54l15tag/nrf54l15tag_cpuflpr_common.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nordic/nrf54l15_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54l15_cpuflpr.dtsi>
 
 #include "nrf54l15tag_common.dtsi"
 

--- a/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr.dts
@@ -11,19 +11,6 @@
 / {
 	model = "Nordic nRF54L15 TAG nRF54L15 FLPR MCU";
 	compatible = "nordic,nrf54l15tag_nrf54l15-cpuflpr";
-
-	soc {
-		/* Resize SRAM partition */
-		/delete-node/ memory@2002f000;
-
-		cpuflpr_sram: memory@20028000 {
-			compatible = "mmio-sram";
-			reg = <0x20028000 DT_SIZE_K(96)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x20028000 0x18000>;
-		};
-	};
 };
 
 &cpuflpr_rram {

--- a/boards/panasonic/panb611evb/panb611evb_nrf54l15_cpuflpr.dts
+++ b/boards/panasonic/panb611evb/panb611evb_nrf54l15_cpuflpr.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf54l15_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54l15_cpuflpr.dtsi>
 #include "panb611evb_nrf54l15_common.dtsi"
 
 / {

--- a/boards/raytac/an54lq_db_15/raytac_an54lq_db_15_nrf54l15_cpuflpr.dts
+++ b/boards/raytac/an54lq_db_15/raytac_an54lq_db_15_nrf54l15_cpuflpr.dts
@@ -6,7 +6,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf54l15_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54l15_cpuflpr.dtsi>
 #include "raytac_an54lq_db_15_common.dtsi"
 
 / {

--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf54l15_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54l15_cpuflpr.dtsi>
 #include "xiao_nrf54l15_common.dtsi"
 
 / {

--- a/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuflpr.dts
+++ b/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuflpr.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf54l15_cpuflpr.dtsi>
+#include <vendor/nordic/nrf54l15_cpuflpr.dtsi>
 #include "ophelia4ev_common.dtsi"
 
 / {

--- a/dts/arm/nordic/nrf54l_05_10_15_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l_05_10_15_cpuapp.dtsi
@@ -13,11 +13,6 @@ nvic: &cpuapp_nvic {};
 /delete-node/ &cpuflpr;
 /delete-node/ &cpuflpr_clic;
 
-#ifndef USE_NON_SECURE_ADDRESS_MAP
-/delete-node/ &cpuflpr_rram;
-/delete-node/ &cpuflpr_sram;
-#endif
-
 / {
 	chosen {
 		zephyr,bt-hci = &bt_hci_sdc;

--- a/dts/riscv/nordic/nrf54l15_cpuflpr.dtsi
+++ b/dts/riscv/nordic/nrf54l15_cpuflpr.dtsi
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) 2024 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include <nordic/nrf54l15.dtsi>
-#include "nrf54l_05_10_15_cpuflpr.dtsi"

--- a/dts/vendor/nordic/nrf54l05.dtsi
+++ b/dts/vendor/nordic/nrf54l05.dtsi
@@ -7,36 +7,11 @@
 #include "nrf54l_05_10_15.dtsi"
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(72)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(72)>;
-};
-
-/* 72 + 24 = 96KB */
-/ {
-	soc {
-		cpuflpr_sram: memory@20012000 {
-			compatible = "mmio-sram";
-			reg = <0x20012000 DT_SIZE_K(24)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x20012000 DT_SIZE_K(24)>;
-		};
-	};
+	reg = <0x20000000 DT_SIZE_K(96)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(96)>;
 };
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(470)>;
-};
-
-/* 470 + 30 = 500KB */
-&rram_controller {
-	cpuflpr_rram: rram@75800 {
-		compatible = "soc-nv-flash";
-		reg = <0x75800 DT_SIZE_K(30)>;
-		ranges = <0x0 0x75800 DT_SIZE_K(30)>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-		erase-block-size = <4096>;
-		write-block-size = <16>;
-	};
+	reg = <0x0 DT_SIZE_K(500)>;
+	ranges = <0x0 0x0 DT_SIZE_K(500)>;
 };

--- a/dts/vendor/nordic/nrf54l05_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l05_partition.dtsi
@@ -5,15 +5,11 @@
  */
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(500)>;
-};
-
-/* These partition sizes assume no FLPR area in RRAM */
-&cpuapp_rram {
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/nordic/nrf54l10.dtsi
+++ b/dts/vendor/nordic/nrf54l10.dtsi
@@ -7,36 +7,11 @@
 #include "nrf54l_05_10_15.dtsi"
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(144)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(144)>;
-};
-
-/* 144 + 48 = 192KB */
-/ {
-	soc {
-		cpuflpr_sram: memory@20024000 {
-			compatible = "mmio-sram";
-			reg = <0x20024000 DT_SIZE_K(48)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x20024000 DT_SIZE_K(48)>;
-		};
-	};
+	reg = <0x20000000 DT_SIZE_K(192)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(192)>;
 };
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(950)>;
-};
-
-/* 950 + 62 = 1012KB */
-&rram_controller {
-	cpuflpr_rram: rram@ed800 {
-		compatible = "soc-nv-flash";
-		reg = <0xed800 DT_SIZE_K(62)>;
-		ranges = <0x0 0xed800 DT_SIZE_K(62)>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-		erase-block-size = <4096>;
-		write-block-size = <16>;
-	};
+	reg = <0x0 DT_SIZE_K(1012)>;
+	ranges = <0x0 0x0 DT_SIZE_K(1012)>;
 };

--- a/dts/vendor/nordic/nrf54l10_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuapp_partition.dtsi
@@ -5,15 +5,11 @@
  */
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1012)>;
-};
-
-/* These partition sizes assume no FLPR area in RRAM */
-&cpuapp_rram {
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/nordic/nrf54l15.dtsi
+++ b/dts/vendor/nordic/nrf54l15.dtsi
@@ -7,36 +7,11 @@
 #include "nrf54l_05_10_15.dtsi"
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(188)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(188)>;
-};
-
-/* 188 + 68 = 256KB */
-/ {
-	soc {
-		cpuflpr_sram: memory@2002f000 {
-			compatible = "mmio-sram";
-			reg = <0x2002f000 DT_SIZE_K(68)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x2002f000 DT_SIZE_K(68)>;
-		};
-	};
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1428)>;
-};
-
-/* 1428 + 96 = 1524KB */
-&rram_controller {
-	cpuflpr_rram: rram@165000 {
-		compatible = "soc-nv-flash";
-		reg = <0x165000 DT_SIZE_K(96)>;
-		ranges = <0x0 0x165000 DT_SIZE_K(96)>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-		erase-block-size = <4096>;
-		write-block-size = <16>;
-	};
+	reg = <0x0 DT_SIZE_K(1524)>;
+	ranges = <0x0 0x0 DT_SIZE_K(1524)>;
 };

--- a/dts/vendor/nordic/nrf54l15_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuapp_partition.dtsi
@@ -9,12 +9,14 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
+#ifdef WITH_FLPR_PARTITIONS
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(664)>;
@@ -29,5 +31,21 @@
 			label = "storage";
 			reg = <0x15c000 DT_SIZE_K(36)>;
 		};
+#else
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x10000 DT_SIZE_K(712)>;
+		};
+
+		slot1_partition: partition@c2000 {
+			label = "image-1";
+			reg = <0xc2000 DT_SIZE_K(712)>;
+		};
+
+		storage_partition: partition@174000 {
+			label = "storage";
+			reg = <0x174000 DT_SIZE_K(36)>;
+		};
+#endif
 	};
 };

--- a/dts/vendor/nordic/nrf54l15_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuflpr.dtsi
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nordic/nrf54l15.dtsi>
+#include <riscv/nordic/nrf54l_05_10_15_cpuflpr.dtsi>
+
+/* 188 + 68 = 256KB */
+/ {
+	soc {
+		cpuflpr_sram: memory@20028000 {
+			compatible = "mmio-sram";
+			reg = <0x20028000 DT_SIZE_K(96)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x2002f000 DT_SIZE_K(96)>;
+		};
+	};
+};
+
+/* 1428 + 96 = 1524KB */
+&rram_controller {
+	cpuflpr_rram: rram@165000 {
+		compatible = "soc-nv-flash";
+		reg = <0x165000 DT_SIZE_K(96)>;
+		ranges = <0x0 0x165000 DT_SIZE_K(96)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-block-size = <4096>;
+		write-block-size = <16>;
+	};
+};

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -735,6 +735,8 @@
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <16>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/snippets/nordic/nordic-flpr-xip/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr-xip/soc/nrf54l15_cpuapp.overlay
@@ -3,6 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(188)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(188)>;
+};
+
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1428)>;
+	ranges = <0x0 0x0 DT_SIZE_K(1428)>;
+
+	/delete-node/ partitions;
+};
+
 &rram_controller {
 	cpuflpr_rram: rram@165000 {
 		compatible = "soc-nv-flash";
@@ -26,3 +38,6 @@
 &cpuapp_vevif_tx {
 	status = "okay";
 };
+
+#define WITH_FLPR_PARTITIONS
+#include <vendor/nordic/nrf54l15_cpuapp_partition.dtsi>

--- a/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
@@ -25,6 +25,13 @@
 	ranges = <0x0 0x20000000 0x28000>;
 };
 
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1428)>;
+	ranges = <0x0 0x0 DT_SIZE_K(1428)>;
+
+	/delete-node/ partitions;
+};
+
 &rram_controller {
 	cpuflpr_rram: rram@165000 {
 		compatible = "soc-nv-flash";
@@ -45,3 +52,6 @@
 &cpuapp_vevif_tx {
 	status = "okay";
 };
+
+#define WITH_FLPR_PARTITIONS
+#include <vendor/nordic/nrf54l15_cpuapp_partition.dtsi>

--- a/tests/subsys/fs/littlefs/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/subsys/fs/littlefs/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,17 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &slot1_partition;
-
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		small_partition: partition@b6000 {
-			label = "small";
-			reg = <0x000b6000 0x00010000>;
-		};
-	};
+small_partition: &slot1_partition {
+	label = "small";
+	reg = <0xc2000 0x10000>;
 };


### PR DESCRIPTION
…tions

Removes resource reservation for cpuflpr from the cpuapp build and only applies it when either of the flpr snippets are used

Upstream PR #: 103819