### PR TITLE
Jlink erase only mode

### DIFF
--- a/.github/workflows/manifest-PR.yml
+++ b/.github/workflows/manifest-PR.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, closed, reopened]
     branches:
       - main
+      - ncs-v3.2-branch
 
 permissions:
   contents: read
@@ -17,3 +18,4 @@ jobs:
         with:
           token: ${{ secrets.NCS_GITHUB_TOKEN }}
           manifest-pr-title-details: ${{ github.event.pull_request.title }}
+          base-branch: ${{ github.event.pull_request.base.ref == 'ncs-v3.2-branch' && 'v3.2-branch' || 'main' }}

--- a/boards/nordic/nrf54lm20dk/board.cmake
+++ b/boards/nordic/nrf54lm20dk/board.cmake
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SOC_NRF54LM20A_ENGA_CPUAPP)
-  board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+  board_runner_args(jlink "--device=nRF54LM20A_M33" "--speed=4000")
 elseif(CONFIG_SOC_NRF54LM20A_ENGA_CPUFLPR)
-  board_runner_args(jlink "--speed=4000")
+  board_runner_args(jlink "--device=nRF54LM20A_RV32" "--speed=4000")
 endif()
 
 if(CONFIG_BOARD_NRF54LM20DK_NRF54LM20A_CPUAPP_NS)

--- a/doc/connectivity/bluetooth/api/mesh/provisioning.rst
+++ b/doc/connectivity/bluetooth/api/mesh/provisioning.rst
@@ -124,7 +124,9 @@ provisionee:
 
 * **Static OOB:** An authentication value is assigned to the device in
   production, which the provisioner can query in some application specific
-  way.
+  way. For secure provisioning with the BTM_ECDH_P256_HMAC_SHA256_AES_CCM
+  algorithm, the Static OOB value should contain more than 128 bits of entropy
+  to provide adequate security against attacks.
 * **Input OOB:** The user inputs the authentication value. The available input
   actions are listed in :c:enum:`bt_mesh_input_action_t`.
 * **Output OOB:** Show the user the authentication value. The available output

--- a/drivers/i2s/i2s_nrf_tdm.c
+++ b/drivers/i2s/i2s_nrf_tdm.c
@@ -32,11 +32,6 @@ LOG_MODULE_REGISTER(tdm_nrf, CONFIG_I2S_LOG_LEVEL);
  */
 #define NRFX_TDM_STATUS_TRANSFER_STOPPED BIT(1)
 
-/* Due to hardware limitations, the TDM peripheral requires the rx/tx size
- * to be greater than 8 bytes.
- */
-#define NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED 8
-
 /* Maximum clock divider value. Corresponds to CKDIV2. */
 #define NRFX_TDM_MAX_SCK_DIV_VALUE TDM_CONFIG_SCK_DIV_SCKDIV_Max
 #define NRFX_TDM_MAX_MCK_DIV_VALUE TDM_CONFIG_MCK_DIV_DIV_Max
@@ -480,11 +475,9 @@ static int tdm_nrf_configure(const struct device *dev, enum i2s_dir dir,
 
 	__ASSERT_NO_MSG(tdm_cfg->mem_slab != NULL && tdm_cfg->block_size != 0);
 
-	if ((tdm_cfg->block_size % sizeof(uint32_t)) != 0 ||
-		tdm_cfg->block_size <= NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED) {
-		LOG_ERR("This device can only transmit full 32-bit words greater than %u bytes.",
-			NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED);
-		return -EIO;
+	if ((tdm_cfg->block_size % sizeof(uint32_t)) != 0) {
+		LOG_ERR("This device can transfer only full 32-bit words");
+		return -EINVAL;
 	}
 
 	switch (tdm_cfg->word_size) {
@@ -680,18 +673,11 @@ static int tdm_nrf_write(const struct device *dev, void *mem_block, size_t size)
 		return -EIO;
 	}
 
-	if (size > drv_data->tx.cfg.block_size) {
+	if (size > drv_data->tx.cfg.block_size || size < sizeof(uint32_t)) {
 		LOG_ERR("This device can only write blocks up to %u bytes",
 			drv_data->tx.cfg.block_size);
 		return -EIO;
 	}
-
-	if ((size % sizeof(uint32_t)) != 0 || size <= NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED) {
-		LOG_ERR("This device can only write full 32-bit words greater than %u bytes.",
-			NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED);
-		return -EIO;
-	}
-
 	ret = dmm_buffer_out_prepare(drv_cfg->mem_reg, buf.mem_block, buf.size,
 				     (void **)&buf.dmm_buf);
 	ret = k_msgq_put(&drv_data->tx_queue, &buf, SYS_TIMEOUT_MS(drv_data->tx.cfg.timeout));

--- a/drivers/i2s/i2s_nrf_tdm.c
+++ b/drivers/i2s/i2s_nrf_tdm.c
@@ -32,6 +32,11 @@ LOG_MODULE_REGISTER(tdm_nrf, CONFIG_I2S_LOG_LEVEL);
  */
 #define NRFX_TDM_STATUS_TRANSFER_STOPPED BIT(1)
 
+/* Due to hardware limitations, the TDM peripheral requires the rx/tx size
+ * to be greater than 8 bytes.
+ */
+#define NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED 8
+
 /* Maximum clock divider value. Corresponds to CKDIV2. */
 #define NRFX_TDM_MAX_SCK_DIV_VALUE TDM_CONFIG_SCK_DIV_SCKDIV_Max
 #define NRFX_TDM_MAX_MCK_DIV_VALUE TDM_CONFIG_MCK_DIV_DIV_Max
@@ -475,9 +480,11 @@ static int tdm_nrf_configure(const struct device *dev, enum i2s_dir dir,
 
 	__ASSERT_NO_MSG(tdm_cfg->mem_slab != NULL && tdm_cfg->block_size != 0);
 
-	if ((tdm_cfg->block_size % sizeof(uint32_t)) != 0) {
-		LOG_ERR("This device can transfer only full 32-bit words");
-		return -EINVAL;
+	if ((tdm_cfg->block_size % sizeof(uint32_t)) != 0 ||
+		tdm_cfg->block_size <= NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED) {
+		LOG_ERR("This device can only transmit full 32-bit words greater than %u bytes.",
+			NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED);
+		return -EIO;
 	}
 
 	switch (tdm_cfg->word_size) {
@@ -673,11 +680,18 @@ static int tdm_nrf_write(const struct device *dev, void *mem_block, size_t size)
 		return -EIO;
 	}
 
-	if (size > drv_data->tx.cfg.block_size || size < sizeof(uint32_t)) {
+	if (size > drv_data->tx.cfg.block_size) {
 		LOG_ERR("This device can only write blocks up to %u bytes",
 			drv_data->tx.cfg.block_size);
 		return -EIO;
 	}
+
+	if ((size % sizeof(uint32_t)) != 0 || size <= NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED) {
+		LOG_ERR("This device can only write full 32-bit words greater than %u bytes.",
+			NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED);
+		return -EIO;
+	}
+
 	ret = dmm_buffer_out_prepare(drv_cfg->mem_reg, buf.mem_block, buf.size,
 				     (void **)&buf.dmm_buf);
 	ret = k_msgq_put(&drv_data->tx_queue, &buf, SYS_TIMEOUT_MS(drv_data->tx.cfg.timeout));

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -354,7 +354,11 @@ static int pwm_suspend(const struct device *dev)
 	while (!nrfx_pwm_stopped_check(&data->pwm)) {
 	}
 
-	memset(dev->data, 0, sizeof(struct pwm_nrfx_data));
+	/* Explicitly clear driver state that might be invalid after subsequent resume. */
+	data->period_cycles = 0;
+	data->pwm_needed = 0;
+	data->prescaler = 0;
+	data->stop_requested = 0;
 	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
 
 	return 0;

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -75,7 +75,7 @@ static int wdt_nrf_disable(const struct device *dev)
 
 	if (err_code < 0) {
 		/* This can only happen if wdt_nrf_setup() is not called first. */
-		return err_code;
+		return -EFAULT;
 	}
 
 #if defined(WDT_NRFX_SYNC_STOP)

--- a/drivers/wifi/nrf_wifi/inc/fmac_main.h
+++ b/drivers/wifi/nrf_wifi/inc/fmac_main.h
@@ -75,7 +75,7 @@ struct nrf_wifi_vif_ctx_zep {
 #endif /* CONFIG_NET_STATISTICS_ETHERNET_VENDOR */
 	struct net_stats_eth eth_stats;
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
-#if defined(CONFIG_NRF70_STA_MODE) || defined(CONFIG_NRF70_RAW_DATA_RX)
+#if defined(CONFIG_NRF70_STA_MODE) || defined(CONFIG_NRF70_RAW_DATA_TX)
 	bool authorized;
 #endif
 #ifdef CONFIG_NRF70_STA_MODE
@@ -154,6 +154,8 @@ void configure_tx_pwr_settings(struct nrf_wifi_tx_pwr_ctrl_params *tx_pwr_ctrl_p
 void configure_board_dep_params(struct nrf_wifi_board_params *board_params);
 void set_tx_pwr_ceil_default(struct nrf_wifi_tx_pwr_ceil_params *pwr_ceil_params);
 const char *nrf_wifi_get_drv_version(void);
+char *nrf_wifi_sprint_ll_addr_buf(const uint8_t *ll, uint8_t ll_len,
+				   char *buf, int buflen);
 enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv_priv_zep);
 enum nrf_wifi_status nrf_wifi_fmac_dev_rem_zep(struct nrf_wifi_drv_priv_zep *drv_priv_zep);
 struct nrf_wifi_vif_ctx_zep *nrf_wifi_get_vif_ctx(struct net_if *iface);

--- a/drivers/wifi/nrf_wifi/inc/fmac_main.h
+++ b/drivers/wifi/nrf_wifi/inc/fmac_main.h
@@ -75,6 +75,9 @@ struct nrf_wifi_vif_ctx_zep {
 #endif /* CONFIG_NET_STATISTICS_ETHERNET_VENDOR */
 	struct net_stats_eth eth_stats;
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
+#if defined(CONFIG_NRF70_STA_MODE) || defined(CONFIG_NRF70_RAW_DATA_RX)
+	bool authorized;
+#endif
 #ifdef CONFIG_NRF70_STA_MODE
 	unsigned int assoc_freq;
 	enum nrf_wifi_fmac_if_carr_state if_carr_state;

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -114,6 +114,61 @@ static const unsigned int rx3_buf_sz = 1000;
 struct nrf_wifi_drv_priv_zep rpu_drv_priv_zep;
 static K_MUTEX_DEFINE(reg_lock);
 
+/**
+ * @brief Format a link layer address to a string buffer.
+ *
+ * @param ll Pointer to the link layer address bytes.
+ * @param ll_len Length of the link layer address (typically 6 for MAC).
+ * @param buf Buffer to store the formatted string.
+ * @param buflen Size of the buffer.
+ *
+ * @return Pointer to the buffer on success, NULL on failure.
+ */
+char *nrf_wifi_sprint_ll_addr_buf(const uint8_t *ll, uint8_t ll_len,
+				   char *buf, int buflen)
+{
+	uint8_t i, len, blen;
+	char *ptr = buf;
+
+	if (ll == NULL) {
+		return "<unknown>";
+	}
+
+	switch (ll_len) {
+	case 8:
+		len = 8U;
+		break;
+	case 6:
+		len = 6U;
+		break;
+	case 2:
+		len = 2U;
+		break;
+	default:
+		len = 6U;
+		break;
+	}
+
+	for (i = 0U, blen = buflen; i < len && blen > 0; i++) {
+		uint8_t high = (ll[i] >> 4) & 0x0f;
+		uint8_t low = ll[i] & 0x0f;
+
+		*ptr++ = (high < 10) ? (char)(high + '0') :
+			 (char)(high - 10 + 'A');
+		*ptr++ = (low < 10) ? (char)(low + '0') :
+			 (char)(low - 10 + 'A');
+		*ptr++ = ':';
+		blen -= 3U;
+	}
+
+	if (!(ptr - buf)) {
+		return NULL;
+	}
+
+	*(ptr - 1) = '\0';
+	return buf;
+}
+
 const char *nrf_wifi_get_drv_version(void)
 {
 	return NRF70_DRIVER_VERSION;

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -25,13 +25,11 @@ LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 
 #include "util.h"
 #include "common/fmac_util.h"
+#include "system/fmac_peer.h"
 #include "shim.h"
 #include "fmac_main.h"
 #include "wpa_supp_if.h"
 #include "net_if.h"
-
-extern char *net_sprint_ll_addr_buf(const uint8_t *ll, uint8_t ll_len,
-				    char *buf, int buflen);
 
 #ifdef CONFIG_NRF70_STA_MODE
 static struct net_if_mcast_monitor mcast_monitor;
@@ -388,6 +386,9 @@ int nrf_wifi_if_send(const struct device *dev,
 	struct rpu_host_stats *host_stats = NULL;
 	void *nbuf = NULL;
 	bool locked = false;
+	unsigned char *ra = NULL;
+	int peer_id = -1;
+	bool authorized;
 
 	if (!dev || !pkt) {
 		LOG_ERR("%s: vif_ctx_zep is NULL", __func__);
@@ -436,12 +437,30 @@ int nrf_wifi_if_send(const struct device *dev,
 						      nbuf);
 	} else {
 #endif /* CONFIG_NRF70_RAW_DATA_TX */
-		if ((vif_ctx_zep->if_carr_state != NRF_WIFI_FMAC_IF_CARR_STATE_ON) ||
-		    (!vif_ctx_zep->authorized && !is_eapol(pkt))) {
-			ret = -EPERM;
+
+		ra = nrf_wifi_util_get_ra(sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx], nbuf);
+		peer_id = nrf_wifi_fmac_peer_get_id(rpu_ctx_zep->rpu_ctx, ra);
+		if (peer_id == -1) {
+			char ra_buf[18] = {0};
+
+			LOG_ERR("%s: Got packet for unknown PEER: %s", __func__,
+				nrf_wifi_sprint_ll_addr_buf(ra, 6, ra_buf,
+							    sizeof(ra_buf)));
 			goto drop;
 		}
 
+		/* VIF or per-peer depending on RA */
+		if (peer_id == MAX_PEERS) {
+			authorized = vif_ctx_zep->authorized;
+		} else {
+			authorized = sys_dev_ctx->tx_config.peers[peer_id].authorized;
+		}
+
+		if ((vif_ctx_zep->if_carr_state != NRF_WIFI_FMAC_IF_CARR_STATE_ON) ||
+		    (!authorized && !is_eapol(pkt))) {
+			ret = -EPERM;
+			goto drop;
+		}
 		ret = nrf_wifi_fmac_start_xmit(rpu_ctx_zep->rpu_ctx,
 					       vif_ctx_zep->vif_idx,
 					       nbuf);
@@ -484,7 +503,6 @@ static void ip_maddr_event_handler(struct net_if *iface,
 	struct net_eth_addr mac_addr;
 	struct nrf_wifi_umac_mcast_cfg *mcast_info = NULL;
 	enum nrf_wifi_status status;
-	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
 	int ret;
 
@@ -540,12 +558,15 @@ static void ip_maddr_event_handler(struct net_if *iface,
 					      vif_ctx_zep->vif_idx,
 					      mcast_info);
 	if (status == NRF_WIFI_STATUS_FAIL) {
+		char mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
+
 		LOG_ERR("%s: nrf_wifi_fmac_set_multicast failed	for"
 			" mac addr=%s",
 			__func__,
-			net_sprint_ll_addr_buf(mac_addr.addr,
-					       WIFI_MAC_ADDR_LEN, mac_string_buf,
-					       sizeof(mac_string_buf)));
+			nrf_wifi_sprint_ll_addr_buf(mac_addr.addr,
+						   WIFI_MAC_ADDR_LEN,
+						   mac_string_buf,
+						   sizeof(mac_string_buf)));
 	}
 unlock:
 	nrf_wifi_osal_mem_free(mcast_info);

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -25,7 +25,6 @@ LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 
 #include "util.h"
 #include "common/fmac_util.h"
-#include "system/fmac_peer.h"
 #include "shim.h"
 #include "fmac_main.h"
 #include "wpa_supp_if.h"
@@ -389,8 +388,6 @@ int nrf_wifi_if_send(const struct device *dev,
 	struct rpu_host_stats *host_stats = NULL;
 	void *nbuf = NULL;
 	bool locked = false;
-	unsigned char *ra = NULL;
-	int peer_id = -1;
 
 	if (!dev || !pkt) {
 		LOG_ERR("%s: vif_ctx_zep is NULL", __func__);
@@ -439,20 +436,12 @@ int nrf_wifi_if_send(const struct device *dev,
 						      nbuf);
 	} else {
 #endif /* CONFIG_NRF70_RAW_DATA_TX */
-
-		ra = nrf_wifi_util_get_ra(sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx], nbuf);
-		peer_id = nrf_wifi_fmac_peer_get_id(rpu_ctx_zep->rpu_ctx, ra);
-		if (peer_id == -1) {
-			nrf_wifi_osal_log_dbg("%s: Invalid peer",
-				      __func__);
-			goto out;
-		}
-
 		if ((vif_ctx_zep->if_carr_state != NRF_WIFI_FMAC_IF_CARR_STATE_ON) ||
-		    (!sys_dev_ctx->tx_config.peers[peer_id].authorized && !is_eapol(pkt))) {
+		    (!vif_ctx_zep->authorized && !is_eapol(pkt))) {
 			ret = -EPERM;
 			goto drop;
 		}
+
 		ret = nrf_wifi_fmac_start_xmit(rpu_ctx_zep->rpu_ctx,
 					       vif_ctx_zep->vif_idx,
 					       nbuf);

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -441,11 +441,16 @@ int nrf_wifi_if_send(const struct device *dev,
 		ra = nrf_wifi_util_get_ra(sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx], nbuf);
 		peer_id = nrf_wifi_fmac_peer_get_id(rpu_ctx_zep->rpu_ctx, ra);
 		if (peer_id == -1) {
+			/* TODO: Make this an error once we fix ping_work sending packets despite
+			 * the interface being dormant
+			 */
+#if CONFIG_WIFI_NRF70_LOG_LEVEL >= LOG_LEVEL_DBG
 			char ra_buf[18] = {0};
 
-			LOG_ERR("%s: Got packet for unknown PEER: %s", __func__,
+			LOG_DBG("%s: Got packet for unknown PEER: %s", __func__,
 				nrf_wifi_sprint_ll_addr_buf(ra, 6, ra_buf,
 							    sizeof(ra_buf)));
+#endif
 			goto drop;
 		}
 

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
@@ -875,18 +875,6 @@ int nrf_wifi_channel(const struct device *dev,
 		return ret;
 	}
 
-	for (i = 0; i < MAX_PEERS; i++) {
-		peer = &sys_dev_ctx->tx_config.peers[i];
-		if (peer->peer_id == -1) {
-			continue;
-		}
-		if (peer->authorized) {
-			LOG_ERR("%s: Cannot change channel when in station connected mode",
-				__func__);
-			return ret;
-		}
-	}
-
 	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
 	if (!rpu_ctx_zep) {
 		LOG_ERR("%s: rpu_ctx_zep is NULL", __func__);
@@ -901,6 +889,18 @@ int nrf_wifi_channel(const struct device *dev,
 
 	fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
 	sys_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+
+	for (i = 0; i < MAX_PEERS; i++) {
+		peer = &sys_dev_ctx->tx_config.peers[i];
+		if (peer->peer_id == -1) {
+			continue;
+		}
+		if (peer->authorized) {
+			LOG_ERR("%s: Cannot change channel when in station connected mode",
+				__func__);
+			return ret;
+		}
+	}
 
 	if (channel->oper == WIFI_MGMT_SET) {
 		/**

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
@@ -18,7 +18,6 @@
 #include "system/fmac_api.h"
 #include "system/fmac_tx.h"
 #include "common/fmac_util.h"
-#include "common/fmac_structs_common.h"
 #include "fmac_main.h"
 #include "wifi_mgmt.h"
 
@@ -758,8 +757,6 @@ int nrf_wifi_mode(const struct device *dev,
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
 	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
-	struct peers_info *peer = NULL;
-	int i = 0;
 	int ret = -1;
 
 	if (!dev || !mode) {
@@ -801,16 +798,10 @@ int nrf_wifi_mode(const struct device *dev,
 			goto out;
 		}
 
-		for (i = 0; i < MAX_PEERS; i++) {
-			peer = &sys_dev_ctx->tx_config.peers[i];
-			if (peer->peer_id == -1) {
-				continue;
-			}
-			if (peer->authorized && (mode->mode == NRF_WIFI_MONITOR_MODE)) {
-				LOG_ERR("%s: Cannot set monitor mode when station is connected",
-					__func__);
-					goto out;
-			}
+		if (vif_ctx_zep->authorized && (mode->mode == NRF_WIFI_MONITOR_MODE)) {
+			LOG_ERR("%s: Cannot set monitor mode when station is connected",
+				__func__);
+			goto out;
 		}
 
 		/**
@@ -860,8 +851,6 @@ int nrf_wifi_channel(const struct device *dev,
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
-	struct peers_info *peer = NULL;
-	int i = 0;
 	int ret = -1;
 
 	if (!dev || !channel) {
@@ -875,16 +864,9 @@ int nrf_wifi_channel(const struct device *dev,
 		return ret;
 	}
 
-	for (i = 0; i < MAX_PEERS; i++) {
-		peer = &sys_dev_ctx->tx_config.peers[i];
-		if (peer->peer_id == -1) {
-			continue;
-		}
-		if (peer->authorized) {
-			LOG_ERR("%s: Cannot change channel when in station connected mode",
-				__func__);
-			return ret;
-		}
+	if (vif_ctx_zep->authorized) {
+		LOG_ERR("%s: Cannot change channel when in station connected mode", __func__);
+		return ret;
 	}
 
 	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;

--- a/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
@@ -17,6 +17,7 @@
 #include "common/fmac_util.h"
 #include "wifi_mgmt.h"
 #include "wpa_supp_if.h"
+#include <system/fmac_peer.h>
 
 LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 
@@ -1107,6 +1108,7 @@ int nrf_wifi_wpa_set_supp_port(void *if_priv, int authorized, char *bssid)
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_umac_chg_sta_info chg_sta_info;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	int ret = -1;
 
@@ -1128,6 +1130,12 @@ int nrf_wifi_wpa_set_supp_port(void *if_priv, int authorized, char *bssid)
 		goto out;
 	}
 
+	sys_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
+	if (!sys_dev_ctx) {
+		LOG_ERR("%s: sys_dev_ctx is NULL", __func__);
+		goto out;
+	}
+
 	if (vif_ctx_zep->if_op_state != NRF_WIFI_FMAC_IF_OP_STATE_UP) {
 		LOG_DBG("%s: Interface not UP, ignoring", __func__);
 		ret = 0;
@@ -1139,7 +1147,6 @@ int nrf_wifi_wpa_set_supp_port(void *if_priv, int authorized, char *bssid)
 	memcpy(chg_sta_info.mac_addr, bssid, ETH_ALEN);
 
 	vif_ctx_zep->authorized = authorized;
-
 	if (authorized) {
 		/* BIT(NL80211_STA_FLAG_AUTHORIZED) */
 		chg_sta_info.sta_flags2.nrf_wifi_mask = 1 << 1;
@@ -1155,6 +1162,10 @@ int nrf_wifi_wpa_set_supp_port(void *if_priv, int authorized, char *bssid)
 		LOG_ERR("%s: nrf_wifi_sys_fmac_chg_sta failed", __func__);
 		ret = -1;
 		goto out;
+	}
+
+	if (vif_ctx_zep->if_type == NRF_WIFI_IFTYPE_STATION) {
+		sys_dev_ctx->tx_config.peers[0].authorized = authorized;
 	}
 
 	ret = 0;
@@ -2989,8 +3000,11 @@ int nrf_wifi_wpa_supp_sta_set_flags(void *if_priv, const u8 *addr,
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_umac_chg_sta_info chg_sta = {0};
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	int peer_id = -1;
 	int ret = -1;
+	char buf[18] = {0};
 
 	if (!if_priv || !addr) {
 		LOG_ERR("%s: Invalid params", __func__);
@@ -3012,17 +3026,45 @@ int nrf_wifi_wpa_supp_sta_set_flags(void *if_priv, const u8 *addr,
 
 	memcpy(chg_sta.mac_addr, addr, sizeof(chg_sta.mac_addr));
 
+	if (!net_eth_is_addr_valid((struct net_eth_addr *)&chg_sta.mac_addr)) {
+		LOG_ERR("%s: Invalid peer MAC address: %s", __func__,
+			nrf_wifi_sprint_ll_addr_buf(chg_sta.mac_addr, 6, buf,
+						    sizeof(buf)));
+		goto out;
+	}
+
+	peer_id = nrf_wifi_fmac_peer_get_id(rpu_ctx_zep->rpu_ctx, chg_sta.mac_addr);
+	if (peer_id == -1) {
+		LOG_ERR("%s: Unknown PEER: %s", __func__,
+			nrf_wifi_sprint_ll_addr_buf(chg_sta.mac_addr, 6, buf,
+						    sizeof(buf)));
+		goto out;
+	}
+
+	if (peer_id == MAX_PEERS) {
+		LOG_ERR("%s: Invalid PEER (group): %s", __func__,
+			nrf_wifi_sprint_ll_addr_buf(chg_sta.mac_addr, 6, buf,
+						    sizeof(buf)));
+		goto out;
+	}
+
 	chg_sta.sta_flags2.nrf_wifi_mask = nrf_wifi_sta_flags_to_nrf(flags_or | ~flags_and);
 	chg_sta.sta_flags2.nrf_wifi_set = nrf_wifi_sta_flags_to_nrf(flags_or);
 
 	LOG_DBG("%s %x, %x", __func__,
 		chg_sta.sta_flags2.nrf_wifi_set, chg_sta.sta_flags2.nrf_wifi_mask);
 
-	status = nrf_wifi_sys_fmac_chg_sta(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &chg_sta);
+	status = nrf_wifi_sys_fmac_chg_sta(rpu_ctx_zep->rpu_ctx,
+		vif_ctx_zep->vif_idx, &chg_sta);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		LOG_ERR("%s: nrf_wifi_sys_fmac_chg_sta failed", __func__);
 		goto out;
 	}
+
+	sys_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
+
+	sys_dev_ctx->tx_config.peers[peer_id].authorized =
+		!!(chg_sta.sta_flags2.nrf_wifi_set & NRF_WIFI_STA_FLAG_AUTHORIZED);
 
 	ret = 0;
 

--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -196,15 +196,22 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout);
  * @ref bt_buf_get_rx function. However, this callback is called from the context of the buffer
  * freeing operation and must not attempt to allocate a new buffer from the same pool.
  *
- * @warning When this callback is called, the scheduler is locked and the callee must not perform
- * any action that makes the current thread unready. This callback must only be used for very
- * short non-blocking operation (e.g. submitting a work item).
+ * This callback must only be used for very short non-blocking operations (e.g. submitting a work
+ * item). When called from thread context, the scheduler is locked during execution and the
+ * callee must not perform any action that makes the current thread unready. When called from ISR
+ * context, the callback runs without scheduler lock.
+ *
+ * @funcprops \isr_ok
  *
  * @param type_mask A bit mask of buffer types that have been freed.
  */
 typedef void (*bt_buf_rx_freed_cb_t)(enum bt_buf_type type_mask);
 
 /** Set the callback to notify about freed buffer in the incoming data pool.
+ *
+ * It's safe to call this inside the callback itself.
+ *
+ * @funcprops \isr_ok
  *
  * @param cb Callback to notify about freed buffer in the incoming data pool. If NULL, the callback
  *           is disabled.

--- a/lib/os/reboot.c
+++ b/lib/os/reboot.c
@@ -11,6 +11,10 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/debug/gcov.h>
 
+#ifdef CONFIG_ZERO_LATENCY_IRQS
+#include <soc.h>
+#endif
+
 extern void sys_arch_reboot(int type);
 
 FUNC_NORETURN void sys_reboot(int type)
@@ -20,6 +24,14 @@ FUNC_NORETURN void sys_reboot(int type)
 #endif /* CONFIG_COVERAGE_DUMP */
 
 	(void)irq_lock();
+
+#ifdef CONFIG_ZERO_LATENCY_IRQS
+	/*
+	 * Disable all IRQs including zero latency interrupts. This ensures
+	 * nothing can interrupt the reboot procedure.
+	 */
+	__disable_irq();
+#endif
 
 	/* Disable caches to ensure all data is flushed */
 #if defined(CONFIG_ARCH_CACHE)

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -60,7 +60,7 @@ config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 	# overflow issues. Need to identify the cause for higher stack usage.
 	default 8192 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	# This is needed to handle stack overflow issues on nRF Wi-Fi drivers.
-	default 5900 if WIFI_NM_WPA_SUPPLICANT_AP
+	default 6144 if WIFI_NM_WPA_SUPPLICANT_AP
 	default 5800
 
 config WIFI_NM_WPA_SUPPLICANT_WQ_STACK_SIZE

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -420,6 +420,10 @@ if (CONFIG_BUILD_WITH_TFM)
     ${TFM_INTERFACE_LIB_DIR}/s_veneers.o
     )
 
+  # Ensure that the generated syscall include headers of Zephyr are available to TF-M
+  # because some platforms might use the same source files for both builds.
+  add_dependencies(tfm ${SYSCALL_LIST_H_TARGET})
+
   # To ensure that generated include files are created before they are used.
   add_dependencies(zephyr_interface tfm)
 

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -432,6 +432,14 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         if self.erase:
             lines.append('erase') # Erase all flash sectors
 
+        # If erase-only mode, skip flashing and return early
+        if self.erase:
+            # Only erase, don't flash
+            lines.append('q') # Close the connection and quit
+            self.logger.debug('JLink commander script (erase only):\n' +
+                              '\n'.join(lines))
+            return None, lines
+
         # Get the build artifact to flash
         if self.file is not None:
             # use file provided by the user
@@ -556,6 +564,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
         if flash_file:
             self.logger.info(f'Flashing file: {flash_file}')
+        else:
+            self.logger.info('Erasing flash only (no file will be flashed)')
         kwargs = {}
         if not self.logger.isEnabledFor(logging.DEBUG):
             kwargs['stdout'] = subprocess.DEVNULL

--- a/soc/nordic/common/Kconfig.peripherals
+++ b/soc/nordic/common/Kconfig.peripherals
@@ -42,7 +42,8 @@ config HAS_HW_NRF_DCNF
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_DCNF))
 
 config HAS_HW_NRF_DPPIC
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_DPPIC))
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_DPPIC)) || \
+		 $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_DPPIC_LOCAL))
 
 config HAS_HW_NRF_ECB
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_ECB))

--- a/soc/nordic/common/gppi_init.c
+++ b/soc/nordic/common/gppi_init.c
@@ -7,6 +7,8 @@
 #include <helpers/nrfx_gppi.h>
 #if defined(NRFX_GPPI_MULTI_DOMAIN) && !defined(NRFX_GPPI_FIXED_CONNECTIONS)
 #include <soc/interconnect/nrfx_gppi_lumos.h>
+#elif defined(CONFIG_SOC_NRF54H20_CPURAD)
+#include <nrfx_gppi_cpurad.h>
 #endif
 
 static int gppi_init(void)
@@ -47,6 +49,21 @@ static int gppi_init(void)
 			NRFX_BIT_MASK(DPPIC20_GROUP_NUM_SIZE) & ~NRFX_DPPI20_GROUPS_USED);
 	nrfx_gppi_groups_init(NRFX_GPPI_NODE_DPPIC30,
 			NRFX_BIT_MASK(DPPIC30_GROUP_NUM_SIZE) & ~NRFX_DPPI30_GROUPS_USED);
+#elif defined(CONFIG_SOC_NRF54H20_CPURAD)
+	gppi_instance.routes = nrfx_gppi_routes_get();
+	gppi_instance.route_map = nrfx_gppi_route_map_get();
+	gppi_instance.nodes = nrfx_gppi_nodes_get();
+
+	nrfx_gppi_channel_init(NRFX_GPPI_NODE_DPPIC020,
+			NRFX_BIT_MASK(DPPIC020_CH_NUM_SIZE) & ~NRFX_DPPI020_CHANNELS_USED);
+	nrfx_gppi_channel_init(NRFX_GPPI_NODE_DPPIC030,
+			NRFX_BIT_MASK(DPPIC030_CH_NUM_SIZE) & ~NRFX_DPPI030_CHANNELS_USED);
+	nrfx_gppi_channel_init(NRFX_GPPI_NODE_PPIB020_030,
+			NRFX_BIT_MASK(PPIB020_NTASKSEVENTS_SIZE));
+	nrfx_gppi_groups_init(NRFX_GPPI_NODE_DPPIC020,
+			NRFX_BIT_MASK(DPPIC020_GROUP_NUM_SIZE) & ~NRFX_DPPI020_GROUPS_USED);
+	nrfx_gppi_groups_init(NRFX_GPPI_NODE_DPPIC030,
+			NRFX_BIT_MASK(DPPIC030_GROUP_NUM_SIZE) & ~NRFX_DPPI030_GROUPS_USED);
 #else
 #error "Not supported"
 #endif

--- a/soc/nordic/common/nrf_sys_event.c
+++ b/soc/nordic/common/nrf_sys_event.c
@@ -76,12 +76,20 @@ int nrf_sys_event_release_global_constlat(void)
 
 int nrf_sys_event_request_global_constlat(void)
 {
-	return nrfx_power_constlat_mode_request();
+	int err;
+
+	err = nrfx_power_constlat_mode_request();
+
+	return (err == 0 || err == -EALREADY) ? 0 : -EAGAIN;
 }
 
 int nrf_sys_event_release_global_constlat(void)
 {
-	return nrfx_power_constlat_mode_free();
+	int err;
+
+	err = nrfx_power_constlat_mode_free();
+
+	return (err == 0 || err == -EBUSY) ? 0 : -EAGAIN;
 }
 
 #endif

--- a/soc/nordic/common/uicr/gen_uicr/Kconfig
+++ b/soc/nordic/common/uicr/gen_uicr/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config IS_GEN_UICR_IMAGE
+	default y
+
+source "Kconfig.zephyr"

--- a/soc/nordic/nrf54h/CMakeLists.txt
+++ b/soc/nordic/nrf54h/CMakeLists.txt
@@ -17,6 +17,10 @@ if(NOT CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE)
   zephyr_library_sources_ifdef(CONFIG_PM_S2RAM pm_s2ram.c)
 endif()
 
+if(CONFIG_NRFX_GPPI AND NOT CONFIG_NRFX_GPPI_V1)
+  zephyr_library_sources_ifdef(CONFIG_SOC_NRF54H20_CPURAD nrfx_gppi_cpurad.c)
+endif()
+
 zephyr_include_directories(.)
 
 # Ensure that image size aligns with 16 bytes so that MRAMC finalizes all writes

--- a/soc/nordic/nrf54h/nrfx_gppi_cpurad.c
+++ b/soc/nordic/nrf54h/nrfx_gppi_cpurad.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "nrfx_gppi_cpurad.h"
+
+static nrfx_atomic_t channels[NRFX_GPPI_NODE_COUNT];
+static nrfx_atomic_t group_channels[NRFX_GPPI_NODE_DPPI_COUNT];
+
+static const nrfx_gppi_node_t nodes[] = {
+	NRFX_GPPI_DPPI_NODE_DEFINE(020, NRFX_GPPI_NODE_DPPIC020),
+	NRFX_GPPI_DPPI_NODE_DEFINE(030, NRFX_GPPI_NODE_DPPIC030),
+	NRFX_GPPI_PPIB_NODE_DEFINE(020, 030),
+};
+
+static const nrfx_gppi_route_t dppi_routes[] = {
+	NRFX_GPPI_ROUTE_DEFINE("slow_rad", (&nodes[NRFX_GPPI_NODE_DPPIC020])),
+	NRFX_GPPI_ROUTE_DEFINE("fast_rad", (&nodes[NRFX_GPPI_NODE_DPPIC030])),
+	NRFX_GPPI_ROUTE_DEFINE("slow_fast_rad",
+			(&nodes[NRFX_GPPI_NODE_DPPIC020],
+			 &nodes[NRFX_GPPI_NODE_PPIB020_030],
+			 &nodes[NRFX_GPPI_NODE_DPPIC030])),
+};
+
+static const nrfx_gppi_route_t *slow_rad_routes[] = {
+	&dppi_routes[0], &dppi_routes[2]
+};
+
+static const nrfx_gppi_route_t *fast_rad_routes[] = {
+	&dppi_routes[1]
+};
+
+static const nrfx_gppi_route_t **dppi_route_map[] = {
+	slow_rad_routes, fast_rad_routes
+};
+
+uint32_t nrfx_gppi_domain_id_get(uint32_t addr)
+{
+	uint32_t domain = (addr >> 24) & BIT_MASK(3);
+	uint32_t bus = (addr >> 16) & BIT_MASK(8);
+
+	(void)domain;
+	__ASSERT_NO_MSG(domain == 3);
+	switch (bus) {
+	case 2:
+		return NRFX_GPPI_NODE_DPPIC020;
+	case 3:
+		return NRFX_GPPI_NODE_DPPIC030;
+	default:
+		__ASSERT_NO_MSG(0);
+		return 0;
+	}
+}
+
+const nrfx_gppi_route_t ***nrfx_gppi_route_map_get(void)
+{
+	return dppi_route_map;
+}
+
+const nrfx_gppi_route_t *nrfx_gppi_routes_get(void)
+{
+	return dppi_routes;
+}
+
+const nrfx_gppi_node_t *nrfx_gppi_nodes_get(void)
+{
+	return nodes;
+}
+
+void nrfx_gppi_channel_init(nrfx_gppi_node_id_t node_id, uint32_t ch_mask)
+{
+	NRFX_ASSERT(node_id < NRFX_GPPI_NODE_COUNT);
+
+	*nodes[node_id].generic.p_channels = ch_mask;
+}
+
+void nrfx_gppi_groups_init(nrfx_gppi_node_id_t node_id, uint32_t group_mask)
+{
+	NRFX_ASSERT(node_id < NRFX_GPPI_NODE_DPPI_COUNT);
+
+	*nodes[node_id].dppi.p_group_channels = group_mask;
+}

--- a/soc/nordic/nrf54h/nrfx_gppi_cpurad.h
+++ b/soc/nordic/nrf54h/nrfx_gppi_cpurad.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SOC_NORDIC_NRF54H_NRFX_GPPI_CPURAD_H_
+#define SOC_NORDIC_NRF54H_NRFX_GPPI_CPURAD_H_
+
+#include <helpers/nrfx_gppi_routes.h>
+
+typedef enum {
+	NRFX_GPPI_NODE_DPPIC020,
+	NRFX_GPPI_NODE_DPPIC030,
+	NRFX_GPPI_NODE_DPPI_COUNT,
+	NRFX_GPPI_NODE_PPIB020_030 = NRFX_GPPI_NODE_DPPI_COUNT,
+	NRFX_GPPI_NODE_COUNT
+} nrfx_gppi_node_id_t;
+
+const nrfx_gppi_route_t ***nrfx_gppi_route_map_get(void);
+const nrfx_gppi_route_t *nrfx_gppi_routes_get(void);
+const nrfx_gppi_node_t *nrfx_gppi_nodes_get(void);
+void nrfx_gppi_channel_init(nrfx_gppi_node_id_t node_id, uint32_t ch_mask);
+void nrfx_gppi_groups_init(nrfx_gppi_node_id_t node_id, uint32_t group_mask);
+
+#endif /* SOC_NORDIC_NRF54H_NRFX_GPPI_CPURAD_H_ */

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1566,13 +1566,16 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
 		    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
 		    (!atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED) ||
-		     atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED))) {
+		     atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED) ||
+		     !atomic_test_bit(adv->flags, BT_ADV_RPA_VALID))) {
 			bt_id_set_adv_private_addr(adv);
 		}
 	} else {
 		if (!atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
 		    (!atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED) ||
-		     atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED))) {
+		     atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED) ||
+		     (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+		      !atomic_test_bit(adv->flags, BT_ADV_RPA_VALID)))) {
 			bt_id_set_adv_private_addr(adv);
 		}
 	}

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -52,14 +52,18 @@ LOG_MODULE_REGISTER(bt_iso, CONFIG_BT_ISO_LOG_LEVEL);
 #define iso_chan(_iso) ((_iso)->iso.chan);
 
 #if defined(CONFIG_BT_ISO_RX)
-static bt_iso_buf_rx_freed_cb_t buf_rx_freed_cb;
+static atomic_ptr_t buf_rx_freed_cb;
 
 static void iso_rx_buf_destroy(struct net_buf *buf)
 {
+	bt_iso_buf_rx_freed_cb_t cb;
+
+	cb = (bt_iso_buf_rx_freed_cb_t)atomic_ptr_get(&buf_rx_freed_cb);
+
 	net_buf_destroy(buf);
 
-	if (buf_rx_freed_cb) {
-		buf_rx_freed_cb();
+	if (cb != NULL) {
+		cb();
 	}
 }
 
@@ -642,7 +646,7 @@ struct net_buf *bt_iso_get_rx(k_timeout_t timeout)
 
 void bt_iso_buf_rx_freed_cb_set(bt_iso_buf_rx_freed_cb_t cb)
 {
-	buf_rx_freed_cb = cb;
+	atomic_ptr_set(&buf_rx_freed_cb, (void *)cb);
 }
 
 void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -924,10 +924,13 @@ void bt_mesh_net_recv(struct net_buf_simple *data, int8_t rssi,
 	}
 
 	/* Relay if this was a group/virtual address, or if the destination
-	 * was neither a local element nor an LPN we're Friends for.
+	 * was neither a local element nor an LPN we're Friends for, and
+	 * device is not in Friendship as the Low Power node or the message is not encrypted using
+	 * friendship security credentials.
 	 */
-	if (!BT_MESH_ADDR_IS_UNICAST(rx.ctx.recv_dst) ||
-	    (!rx.local_match && !rx.friend_match)) {
+	if ((!BT_MESH_ADDR_IS_UNICAST(rx.ctx.recv_dst) ||
+	    (!rx.local_match && !rx.friend_match)) &&
+	    (!bt_mesh_lpn_established() || !rx.friend_cred)) {
 		net_buf_simple_restore(&buf, &state);
 		bt_mesh_net_relay(&buf, &rx, false);
 	}

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -693,21 +693,21 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 static void stream_connected_cb(struct bt_bap_stream *stream)
 {
 	struct bt_conn_info conn_info;
+	struct bt_bap_ep_info ep_info;
+	int err;
 
 	LOG_DBG("Connected stream %p", stream);
 
+	err = bt_bap_ep_get_info(stream->ep, &ep_info);
+	if (err != 0) {
+		LOG_ERR("Failed to get info: %d", err);
+
+		return;
+	}
+
 	(void)bt_conn_get_info(stream->conn, &conn_info);
+
 	if (conn_info.role == BT_HCI_ROLE_CENTRAL) {
-		struct bt_bap_ep_info ep_info;
-		int err;
-
-		err = bt_bap_ep_get_info(stream->ep, &ep_info);
-		if (err != 0) {
-			LOG_ERR("Failed to get info: %d", err);
-
-			return;
-		}
-
 		if (ep_info.dir == BT_AUDIO_DIR_SOURCE) {
 			if (ep_info.state == BT_BAP_EP_STATE_ENABLING) {
 				/* Automatically do the receiver start ready operation for source
@@ -726,6 +726,18 @@ static void stream_connected_cb(struct bt_bap_stream *stream)
 			btp_send_ascs_operation_completed_ev(stream->conn, u_stream->ase_id,
 							     BT_ASCS_START_OP,
 							     BTP_ASCS_STATUS_SUCCESS);
+		}
+	} else {
+		if (ep_info.dir == BT_AUDIO_DIR_SINK && ep_info.state == BT_BAP_EP_STATE_ENABLING) {
+			/* Automatically do the receiver start ready operation for sink
+			 * ASEs as the server when in the enabling state.
+			 * The CIS may be connected in the QoS Configured state as well, in
+			 * which case we should wait until we enter the enabling state.
+			 */
+			err = bt_bap_stream_start(stream);
+			if (err != 0) {
+				LOG_ERR("Failed to start stream %p", stream);
+			}
 		}
 	}
 

--- a/tests/bluetooth/tester/src/btp/btp_gatt.h
+++ b/tests/bluetooth/tester/src/btp/btp_gatt.h
@@ -347,6 +347,21 @@ struct btp_gatt_cfg_notify_mult_cmd {
 	uint16_t cnt;
 	uint16_t attr_id[];
 } __packed;
+
+#define BTP_GATT_GET_HANDLE_FROM_UUID 0x22
+struct btp_gatt_get_handle_from_uuid_cmd {
+	uint8_t uuid_length;
+	uint8_t uuid[];
+} __packed;
+struct btp_gatt_get_handle_from_uuid_rp {
+	uint16_t handle;
+} __packed;
+
+#define BTP_GATT_REMOVE_HANDLE_FROM_DB 0x23
+struct btp_gatt_remove_handle_from_db_cmd {
+	uint16_t handle;
+} __packed;
+
 /* GATT events */
 #define BTP_GATT_EV_NOTIFICATION		0x80
 struct btp_gatt_notification_ev {

--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -452,6 +452,7 @@ static int alloc_characteristic(struct add_characteristic *ch)
 	chrc_data->uuid = attr_value->uuid;
 
 	ch->char_id = attr_chrc->handle;
+
 	return 0;
 }
 
@@ -2131,6 +2132,71 @@ static uint8_t notify_mult(const void *cmd, uint16_t cmd_len,
 }
 #endif /* CONFIG_BT_GATT_NOTIFY_MULTIPLE */
 
+static uint8_t get_handle_from_uuid(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
+{
+	const struct btp_gatt_get_handle_from_uuid_cmd *cp = cmd;
+	struct btp_gatt_get_handle_from_uuid_rp *rp = rsp;
+	struct bt_uuid search_uuid;
+
+	if (btp2bt_uuid(cp->uuid, cp->uuid_length, &search_uuid)) {
+		return BTP_STATUS_FAILED;
+	}
+
+	__maybe_unused char uuid_str[BT_UUID_STR_LEN];
+
+	bt_uuid_to_str(&search_uuid, uuid_str, sizeof(uuid_str));
+
+	LOG_DBG("Searching handle for UUID %s", uuid_str);
+
+	for (int i = 0; i < attr_count; i++) {
+		if (server_db[i].uuid != NULL &&
+		    bt_uuid_cmp(server_db[i].uuid, &search_uuid) == 0) {
+			rp->handle = sys_cpu_to_le16(server_db[i].handle);
+			*rsp_len = sizeof(*rp);
+
+			return BTP_STATUS_SUCCESS;
+		}
+	}
+
+	LOG_DBG("No handle found");
+	return BTP_STATUS_FAILED;
+}
+
+static uint8_t remove_by_handle_from_db(const void *cmd, uint16_t cmd_len, void *rsp,
+						uint16_t *rsp_len)
+{
+	const struct btp_gatt_remove_handle_from_db_cmd *cp = cmd;
+	uint16_t handle = sys_le16_to_cpu(cp->handle);
+
+	/* Search for the service that contains the attribute with the given handle and unregister
+	 * it.
+	 */
+
+	for (int i = 0; i < svc_count; i++) {
+		for (int j = 0; j < server_svcs[i].attr_count; j++) {
+			if (server_svcs[i].attrs[j].handle == handle) {
+				int err;
+
+				err = bt_gatt_service_unregister(&server_svcs[i]);
+				if (err < 0 && err != -ENOENT) {
+					LOG_ERR("Failed to unregister service [%d]: %d", i, err);
+					return BTP_STATUS_FAILED;
+				}
+
+				if (err == -ENOENT) {
+					LOG_WRN("Service [%d] already unregistered", i);
+				} else {
+					LOG_DBG("Service [%d] unregistered", i);
+				}
+
+				return BTP_STATUS_SUCCESS;
+			}
+		}
+	}
+
+	return BTP_STATUS_FAILED;
+}
+
 struct get_attrs_foreach_data {
 	struct net_buf_simple *buf;
 	const struct bt_uuid *uuid;
@@ -2556,6 +2622,16 @@ static const struct btp_handler handlers[] = {
 		.opcode = BTP_GATT_NOTIFY_MULTIPLE,
 		.expect_len = BTP_HANDLER_LENGTH_VARIABLE,
 		.func = notify_mult,
+	},
+	{
+		.opcode = BTP_GATT_GET_HANDLE_FROM_UUID,
+		.expect_len = BTP_HANDLER_LENGTH_VARIABLE,
+		.func = get_handle_from_uuid,
+	},
+	{
+		.opcode = BTP_GATT_REMOVE_HANDLE_FROM_DB,
+		.expect_len = sizeof(struct btp_gatt_remove_handle_from_db_cmd),
+		.func = remove_by_handle_from_db,
 	},
 };
 

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 564e754139944286208f3eac122781cec4262392
+      revision: e891e1cda4db109c6816cc929dda4f6a18e3e1bc
       path: modules/hal/nordic
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -337,7 +337,7 @@ manifest:
       revision: 5eec7aca321735f5fc8e3e7c79e162f0e9810b16
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: f0b6706cac522371e651f589d53d3026cc6f97dd
+      revision: a39e9b155830461c9d1cf587afb151b894369b91
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: c30a6d8b92fcebdb797fc1a7698e8729e250f637

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: e891e1cda4db109c6816cc929dda4f6a18e3e1bc
+      revision: 0dbbf4794156ca09dc2d4bad8c42dcdb54acd662
       path: modules/hal/nordic
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -337,7 +337,7 @@ manifest:
       revision: 5eec7aca321735f5fc8e3e7c79e162f0e9810b16
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: a39e9b155830461c9d1cf587afb151b894369b91
+      revision: 97c6751657187ab811e73c36cc4c47acb1783fff
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: c30a6d8b92fcebdb797fc1a7698e8729e250f637


### PR DESCRIPTION
[runners: jlink] : support erase-only mode with --erase flag

When --erase flag is used, only perform flash erase operation
without downloading the hex file. This allows users to erase
flash without flashing a new image.

Previously, --erase would always erase and then flash, which
was not the intended behavior for erase-only operations.

Modified get_default_flash_commands() method in jlink.py to
skip file download when erase-only mode is enabled. Added
appropriate log messages to indicate erase-only mode.

Signed-off-by: John <john.liu@evenrealities.com>