### PR TITLE
[nrf fromlist] arch: ISR table size optimization

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -574,9 +574,36 @@ config GEN_SW_ISR_TABLE
 	depends on GEN_ISR_TABLES
 	help
 	  This option controls whether a platform using gen_isr_tables
-	  needs a software ISR table table created. This is an array of struct
-	  _isr_table_entry containing the interrupt service routine and supplied
-	  parameter.
+	  needs a software ISR table created.
+	  It can be generated as either an array or a switch-case.
+	  See CONFIG_GEN_SW_ISR_TABLE_TYPE.
+
+choice GEN_SW_ISR_TABLE_TYPE
+	prompt "Allows to chose how ISR table is implemented"
+	depends on GEN_SW_ISR_TABLE
+	default GEN_SW_ISR_TABLE_ARRAY
+	help
+	  CONFIG_GEN_SW_ISR_TABLE_ARRAY is a default option.
+	  It should be used when in doubt.
+	  GEN_SW_ISR_TABLE_SWITCH allows for binary size optimization
+	  in certain scenarios, but may also increase latency, to execution of ISR with higher number, if there is significant number of ISR assigned in your system.
+
+config GEN_SW_ISR_TABLE_ARRAY
+	bool "Generate an array of ISR entries"
+	help
+	  This is an array of struct _isr_table_entry containing
+	  the interrupt service routine and supplied parameter.
+	  All interrupts have their own entry.
+
+config GEN_SW_ISR_TABLE_SWITCH
+	bool "Generate a function with a switch-case"
+	help
+	  Use a switch-case instead of an array.
+	  This helps to limit binary size when most of the IRQs are not used.
+	  In such case common, duplicated entries are grouped in a single default block
+	  while few used interrupts have their own case blocks.
+
+endchoice
 
 config ARCH_SW_ISR_TABLE_ALIGN
 	int "Alignment size of a software ISR table"

--- a/arch/arm/core/cortex_m/isr_wrapper.c
+++ b/arch/arm/core/cortex_m/isr_wrapper.c
@@ -76,8 +76,15 @@ void _isr_wrapper(void)
 	 */
 	irq_number -= 16;
 
+#if defined(CONFIG_GEN_SW_ISR_TABLE_ARRAY)
 	const struct _isr_table_entry *entry = &_sw_isr_table[irq_number];
 	(entry->isr)(entry->arg);
+#elif defined(CONFIG_GEN_SW_ISR_TABLE_SWITCH)
+	struct _isr_table_entry entry;
+
+	get_isr_entry(irq_number, &entry);
+	(entry.isr)(entry.arg);
+#endif /* CONFIG_GEN_SW_ISR_TABLE_ARRAY */
 
 #if defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
 	z_soc_irq_eoi(irq_number);

--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -87,15 +87,20 @@ const uintptr_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
 /* If there are no interrupts at all, or all interrupts are of the 'direct'
  * type and bypass the _sw_isr_table, then do not generate one.
  */
-#ifdef CONFIG_GEN_SW_ISR_TABLE
+#if defined(CONFIG_GEN_SW_ISR_TABLE_ARRAY)
 #ifndef CONFIG_DYNAMIC_INTERRUPTS
 const
-#endif
-struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
-	[0 ...(IRQ_TABLE_SIZE - 1)] = {(const void *)0x42,
-				       &z_irq_spurious},
+#endif /* CONFIG_DYNAMIC_INTERRUPTS */
+	struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
+		[0 ...(IRQ_TABLE_SIZE - 1)] = {(const void *)0x42, &z_irq_spurious},
 };
-#endif
+#elif defined(CONFIG_GEN_SW_ISR_TABLE_SWITCH)
+void __sw_isr_table get_isr_entry(int irq_number, struct _isr_table_entry *entry)
+{
+	entry->arg = (const void *)0x0;
+	entry->isr = z_irq_spurious;
+}
+#endif /* CONFIG_GEN_SW_ISR_TABLE_ARRAY */
 
 #ifdef CONFIG_SHARED_INTERRUPTS
 #ifndef CONFIG_DYNAMIC_INTERRUPTS

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -41,14 +41,18 @@ struct _isr_table_entry {
 	void (*isr)(const void *);
 };
 
+#if defined(CONFIG_GEN_SW_ISR_TABLE_ARRAY)
 /* The software ISR table itself, an array of these structures indexed by the
  * irq line
  */
 extern
 #ifndef CONFIG_DYNAMIC_INTERRUPTS
-const
-#endif
-struct _isr_table_entry _sw_isr_table[];
+	const
+#endif /* CONFIG_DYNAMIC_INTERRUPTS */
+	struct _isr_table_entry _sw_isr_table[];
+#elif defined(CONFIG_GEN_SW_ISR_TABLE_SWITCH)
+extern void __sw_isr_table get_isr_entry(int irq_number, struct _isr_table_entry *entry);
+#endif /* CONFIG_GEN_SW_ISR_TABLE_ARRAY */
 
 struct _irq_parent_entry {
 	const struct device *dev;

--- a/scripts/build/gen_isr_tables_parser_carrays.py
+++ b/scripts/build/gen_isr_tables_parser_carrays.py
@@ -253,23 +253,58 @@ typedef void (* ISR)(const void *);
 
         fp.write("};\n")
 
-    def write_source(self, fp):
-        fp.write(self.source_header)
+    def write_isr_switch_start(self, fp):
+        fp.write("void __sw_isr_table ")
+        fp.write("get_isr_entry(int irq_index, struct _isr_table_entry *entry)\n")
+        fp.write("{\n")
+        fp.write("\tswitch (irq_index)\n")
+        fp.write("\t{\n")
 
-        if self.__config.check_shared_interrupts():
-            self.__write_shared_table(fp)
+    def write_isr_case_block(self, fp, i, isr, arg):
+        fp.write(f"\t\tcase {i}:\n")
+        fp.write("\t\t{\n")
+        fp.write(f"\t\t\tentry->isr = (ISR){isr:#x};\n")
+        fp.write(f"\t\t\tentry->arg = (const void *){arg};\n")
+        fp.write("\t\t\tbreak;\n")
+        fp.write("\t\t}\n")
 
-        if self.__vt:
-            if self.__config.check_sym("CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_ADDRESS"):
-                self.__write_address_irq_vector_table(fp)
-            elif self.__config.check_sym("CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_CODE"):
-                self.__write_code_irq_vector_table(fp)
+    def write_isr_case_single_irq(self, fp, i):
+        arg = f"{self.__swt[i][0][0]:#x}"
+        isr = self.__swt[i][0][1]
+        self.write_isr_case_block(fp, i, isr, arg)
+
+    def write_isr_case_shared_irq(self, fp, i):
+        arg = f"&z_shared_sw_isr_table[{i}]"
+        isr = self.__config.swt_shared_handler
+        self.write_isr_case_block(fp, i, isr, arg)
+
+    def write_isr_case_default_block(self, fp):
+        fp.write("\t\tdefault:\n")
+        fp.write("\t\t{\n")
+        fp.write(f"\t\t\tentry->isr = (ISR){self.__config.swt_spurious_handler};\n")
+        fp.write("\t\t\tentry->arg = (const void *)0x0;\n")
+        fp.write("\t\t\tbreak;\n")
+        fp.write("\t\t}\n")
+        fp.write("\t}\n")
+        fp.write("}\n")
+
+    def write_isr_table_switch(self, fp):
+        self.write_isr_switch_start(fp)
+
+        for i in range(self.__nv):
+            if len(self.__swt[i]) == 0:
+                # Unused interrupt - default will be used
+                continue
+            elif len(self.__swt[i]) == 1:
+                # Single interrupt
+                self.write_isr_case_single_irq(fp, i)
             else:
-                self.__log.error("CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_{ADDRESS,CODE} not set")
+                # Shared interrupt
+                self.write_isr_case_shared_irq(fp, i)
 
-        if not self.__swt:
-            return
+        self.write_isr_case_default_block(fp)
 
+    def write_isr_table_array(self, fp):
         if not self.__config.check_sym("CONFIG_DYNAMIC_INTERRUPTS"):
             fp.write("const ")
         fp.write(f"struct _isr_table_entry __sw_isr_table _sw_isr_table[{self.__nv}] = {{\n")
@@ -303,3 +338,29 @@ typedef void (* ISR)(const void *);
 
             fp.write(f"\t{{(const void *){param}, (ISR){func_as_string}}}, /* {i} */\n")
         fp.write("};\n")
+
+    def write_source(self, fp):
+        fp.write(self.source_header)
+
+        if self.__config.check_shared_interrupts():
+            self.__write_shared_table(fp)
+
+        if self.__vt:
+            if self.__config.check_sym("CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_ADDRESS"):
+                self.__write_address_irq_vector_table(fp)
+            elif self.__config.check_sym("CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_CODE"):
+                self.__write_code_irq_vector_table(fp)
+            else:
+                self.__log.error("CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_{ADDRESS,CODE} not set")
+
+        if not self.__swt:
+            return
+
+        fp.write("\n")
+
+        if self.__config.get_sym("CONFIG_GEN_SW_ISR_TABLE_ARRAY"):
+            self.write_isr_table_array(fp)
+        elif self.__config.get_sym("CONFIG_GEN_SW_ISR_TABLE_SWITCH"):
+            self.write_isr_table_switch(fp)
+        else:
+            raise ValueError("Unsupported CONFIG_GEN_SW_ISR_TABLE_TYPE")


### PR DESCRIPTION
Upstream PR #: 106754

Allow to use a switch-case instead of an array holding ISR entries.

When most of IRQs are not used, they share the same, default entry.
It results in most of the ISR array entries being identical duplicates.

This change allows to use dynamically generated function (after first
linker pass) that uses switch-case instead of a full array.
Default entries are handled only once, in a default section.
Used IRQs have their own case sections.
This can help reduce binary size.

Ref: NCSDK-33388