### PR TITLE
[nrf fromtree] scripts: west: nrf_common: Provision slot invalidation…

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -394,6 +394,12 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
 
         self.op_program(self.hex_, erase_arg, ext_mem_erase_opt, defer=True, core=core)
 
+        # provision relevant slots if prot_ram_inv_slots.json exists in the build directory
+        prot_ram_inv_slots = Path(self.cfg.build_dir).parent / 'prot_ram_inv_slots.json'
+        if prot_ram_inv_slots.exists():
+            self.logger.info(f'Provisioning key file: {prot_ram_inv_slots}')
+            self.exec_op('x-provision-keys', keyfile=str(prot_ram_inv_slots), defer=True)
+
         if self.erase or self.recover:
             # provision keys if keyfile.json exists in the build directory
             keyfile = Path(self.cfg.build_dir).parent / 'keyfile.json'


### PR DESCRIPTION
… json

The nRF54L series devices require to reserve 2 KMU slots which are filled with random data used for invalidating the Protected RAM. Until now the provisioning of these slots happends in firmware which costs in both volatile and non volatile memory.

Instead of doing this nrfutil recently added the funcionality to provision these slots using a .json file which means that everything can be handled by the build system now.

This is preparation work, that is needed before the full integration arrives. The change checks if a json file with the name: "prot_ram_inv_slots.json" exists and if it does it invokes nrfutil with the provisioning command.


(cherry picked from commit ee6fda031108a5ab599ded90c494ab785ea8f02f)