### PR TITLE
Changes required for sEMMC shim driver

### DIFF
--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -148,18 +148,6 @@ static void port_pin_clock_set(uint16_t pin_number, bool enable)
 
 #endif
 
-#if DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || \
-	defined(CONFIG_MSPI_HPF) || \
-	DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
-#if defined(CONFIG_SOC_SERIES_NRF54LX)
-#define NRF_PSEL_SDP_MSPI(psel) \
-	nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_VPR);
-#elif defined(CONFIG_SOC_SERIES_NRF54HX)
-/* On nRF54H, pin routing is controlled by secure domain, via UICR. */
-#define NRF_PSEL_SDP_MSPI(psel)
-#endif
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || ... */
-
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			   uintptr_t reg)
 {
@@ -541,26 +529,6 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_coresight_nrf) */
-#if defined(NRF_PSEL_SDP_MSPI)
-		case NRF_FUN_SDP_MSPI_CS0:
-		case NRF_FUN_SDP_MSPI_CS1:
-		case NRF_FUN_SDP_MSPI_CS2:
-		case NRF_FUN_SDP_MSPI_CS3:
-		case NRF_FUN_SDP_MSPI_CS4:
-		case NRF_FUN_SDP_MSPI_SCK:
-		case NRF_FUN_SDP_MSPI_DQ0:
-		case NRF_FUN_SDP_MSPI_DQ1:
-		case NRF_FUN_SDP_MSPI_DQ2:
-		case NRF_FUN_SDP_MSPI_DQ3:
-		case NRF_FUN_SDP_MSPI_DQ4:
-		case NRF_FUN_SDP_MSPI_DQ5:
-		case NRF_FUN_SDP_MSPI_DQ6:
-		case NRF_FUN_SDP_MSPI_DQ7:
-			NRF_PSEL_SDP_MSPI(psel);
-			dir = NRF_GPIO_PIN_DIR_OUTPUT;
-			input = NRF_GPIO_PIN_INPUT_CONNECT;
-			break;
-#endif /* defined(NRF_PSEL_SDP_MSPI) */
 		default:
 			return -ENOTSUP;
 		}

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -110,6 +110,18 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 #define NRF_PSEL_TDM(reg, line) ((NRF_TDM_Type *)reg)->PSEL.line
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || \
+	defined(CONFIG_MSPI_HPF) || \
+	DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
+#if defined(CONFIG_SOC_SERIES_NRF54L)
+#define NRF_PSEL_SDP_MSPI(psel) \
+	nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_VPR);
+#elif defined(CONFIG_SOC_SERIES_NRF54H)
+/* On nRF54H, pin routing is controlled by secure domain, via UICR. */
+#define NRF_PSEL_SDP_MSPI(psel)
+#endif
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || ... */
+
 #if NRF_GPIO_HAS_RETENTION_SETCLEAR
 
 static void port_pin_retain_set(uint16_t pin_number, bool enable)
@@ -500,6 +512,26 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_qspi_v2) */
+#if defined(NRF_PSEL_SDP_MSPI)
+		case NRF_FUN_SDP_MSPI_CS0:
+		case NRF_FUN_SDP_MSPI_CS1:
+		case NRF_FUN_SDP_MSPI_CS2:
+		case NRF_FUN_SDP_MSPI_CS3:
+		case NRF_FUN_SDP_MSPI_CS4:
+		case NRF_FUN_SDP_MSPI_SCK:
+		case NRF_FUN_SDP_MSPI_DQ0:
+		case NRF_FUN_SDP_MSPI_DQ1:
+		case NRF_FUN_SDP_MSPI_DQ2:
+		case NRF_FUN_SDP_MSPI_DQ3:
+		case NRF_FUN_SDP_MSPI_DQ4:
+		case NRF_FUN_SDP_MSPI_DQ5:
+		case NRF_FUN_SDP_MSPI_DQ6:
+		case NRF_FUN_SDP_MSPI_DQ7:
+			NRF_PSEL_SDP_MSPI(psel);
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
+			break;
+#endif /* defined(NRF_PSEL_SDP_MSPI) */
 #if defined(NRF_PSEL_TWIS)
 		case NRF_FUN_TWIS_SCL:
 			NRF_PSEL_TWIS(reg, SCL) = psel;

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -151,10 +151,10 @@ static void port_pin_clock_set(uint16_t pin_number, bool enable)
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || \
 	defined(CONFIG_MSPI_HPF) || \
 	DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
-#if defined(CONFIG_SOC_SERIES_NRF54L)
+#if defined(CONFIG_SOC_SERIES_NRF54LX)
 #define NRF_PSEL_SDP_MSPI(psel) \
 	nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_VPR);
-#elif defined(CONFIG_SOC_SERIES_NRF54H)
+#elif defined(CONFIG_SOC_SERIES_NRF54HX)
 /* On nRF54H, pin routing is controlled by secure domain, via UICR. */
 #define NRF_PSEL_SDP_MSPI(psel)
 #endif

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -172,62 +172,6 @@
 #define NRF_FUN_GRTC_CLKOUT_FAST 55U
 /** GRTC slow clock output */
 #define NRF_FUN_GRTC_CLKOUT_32K  56U
-/** SDP_MSPI clock pin */
-#define NRF_FUN_SDP_MSPI_SCK 57U
-/** SDP_MSPI data pin 0 */
-#define NRF_FUN_SDP_MSPI_DQ0 58U
-/** SDP_MSPI data pin 1 */
-#define NRF_FUN_SDP_MSPI_DQ1 59U
-/** SDP_MSPI data pin 2 */
-#define NRF_FUN_SDP_MSPI_DQ2 60U
-/** SDP_MSPI data pin 3 */
-#define NRF_FUN_SDP_MSPI_DQ3 61U
-/** SDP_MSPI data pin 4 */
-#define NRF_FUN_SDP_MSPI_DQ4 62U
-/** SDP_MSPI data pin 5 */
-#define NRF_FUN_SDP_MSPI_DQ5 63U
-/** SDP_MSPI data pin 6 */
-#define NRF_FUN_SDP_MSPI_DQ6 64U
-/** SDP_MSPI data pin 7 */
-#define NRF_FUN_SDP_MSPI_DQ7 65U
-/** SDP_MSPI chip select 0 */
-#define NRF_FUN_SDP_MSPI_CS0 66U
-/** SDP_MSPI chip select 1 */
-#define NRF_FUN_SDP_MSPI_CS1 67U
-/** SDP_MSPI chip select 2 */
-#define NRF_FUN_SDP_MSPI_CS2 68U
-/** SDP_MSPI chip select 3 */
-#define NRF_FUN_SDP_MSPI_CS3 69U
-/** SDP_MSPI chip select 4 */
-#define NRF_FUN_SDP_MSPI_CS4 70U
-/** High-Performance Framework MSPI clock pin */
-#define NRF_FUN_HPF_MSPI_SCK NRF_FUN_SDP_MSPI_SCK
-/** High-Performance Framework MSPI data pin 0 */
-#define NRF_FUN_HPF_MSPI_DQ0 NRF_FUN_SDP_MSPI_DQ0
-/** High-Performance Framework MSPI data pin 1 */
-#define NRF_FUN_HPF_MSPI_DQ1 NRF_FUN_SDP_MSPI_DQ1
-/** High-Performance Framework MSPI data pin 2 */
-#define NRF_FUN_HPF_MSPI_DQ2 NRF_FUN_SDP_MSPI_DQ2
-/** High-Performance Framework MSPI data pin 3 */
-#define NRF_FUN_HPF_MSPI_DQ3 NRF_FUN_SDP_MSPI_DQ3
-/** High-Performance Framework MSPI data pin 4 */
-#define NRF_FUN_HPF_MSPI_DQ4 NRF_FUN_SDP_MSPI_DQ4
-/** High-Performance Framework MSPI data pin 5 */
-#define NRF_FUN_HPF_MSPI_DQ5 NRF_FUN_SDP_MSPI_DQ5
-/** High-Performance Framework MSPI data pin 6 */
-#define NRF_FUN_HPF_MSPI_DQ6 NRF_FUN_SDP_MSPI_DQ6
-/** High-Performance Framework MSPI data pin 7 */
-#define NRF_FUN_HPF_MSPI_DQ7 NRF_FUN_SDP_MSPI_DQ7
-/** High-Performance Framework MSPI chip select pin 0 */
-#define NRF_FUN_HPF_MSPI_CS0 NRF_FUN_SDP_MSPI_CS0
-/** High-Performance Framework MSPI chip select pin 1 */
-#define NRF_FUN_HPF_MSPI_CS1 NRF_FUN_SDP_MSPI_CS1
-/** High-Performance Framework MSPI chip select pin 2 */
-#define NRF_FUN_HPF_MSPI_CS2 NRF_FUN_SDP_MSPI_CS2
-/** High-Performance Framework MSPI chip select pin 3 */
-#define NRF_FUN_HPF_MSPI_CS3 NRF_FUN_SDP_MSPI_CS3
-/** High-Performance Framework MSPI chip select pin 4 */
-#define NRF_FUN_HPF_MSPI_CS4 NRF_FUN_SDP_MSPI_CS4
 /** TDM SCK in master mode */
 #define NRF_FUN_TDM_SCK_M        71U
 /** TDM SCK in slave mode */

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -172,6 +172,64 @@
 #define NRF_FUN_GRTC_CLKOUT_FAST 55U
 /** GRTC slow clock output */
 #define NRF_FUN_GRTC_CLKOUT_32K  56U
+/** SDP_MSPI clock pin */
+#define NRF_FUN_SDP_MSPI_SCK 57U
+/** SDP_MSPI data pin 0 */
+#define NRF_FUN_SDP_MSPI_DQ0 58U
+/** SDP_MSPI data pin 1 */
+#define NRF_FUN_SDP_MSPI_DQ1 59U
+/** SDP_MSPI data pin 2 */
+#define NRF_FUN_SDP_MSPI_DQ2 60U
+/** SDP_MSPI data pin 3 */
+#define NRF_FUN_SDP_MSPI_DQ3 61U
+/** SDP_MSPI data pin 4 */
+#define NRF_FUN_SDP_MSPI_DQ4 62U
+/** SDP_MSPI data pin 5 */
+#define NRF_FUN_SDP_MSPI_DQ5 63U
+/** SDP_MSPI data pin 6 */
+#define NRF_FUN_SDP_MSPI_DQ6 64U
+/** SDP_MSPI data pin 7 */
+#define NRF_FUN_SDP_MSPI_DQ7 65U
+/** SDP_MSPI chip select 0 */
+#define NRF_FUN_SDP_MSPI_CS0 66U
+/** SDP_MSPI chip select 1 */
+#define NRF_FUN_SDP_MSPI_CS1 67U
+/** SDP_MSPI chip select 2 */
+#define NRF_FUN_SDP_MSPI_CS2 68U
+/** SDP_MSPI chip select 3 */
+#define NRF_FUN_SDP_MSPI_CS3 69U
+/** SDP_MSPI chip select 4 */
+#define NRF_FUN_SDP_MSPI_CS4 70U
+/** Generic soft peripheral pin */
+#define NRF_FUN_SP_PIN       NRF_FUN_SDP_MSPI_SCK
+/** High-Performance Framework MSPI clock pin */
+#define NRF_FUN_HPF_MSPI_SCK NRF_FUN_SDP_MSPI_SCK
+/** High-Performance Framework MSPI data pin 0 */
+#define NRF_FUN_HPF_MSPI_DQ0 NRF_FUN_SDP_MSPI_DQ0
+/** High-Performance Framework MSPI data pin 1 */
+#define NRF_FUN_HPF_MSPI_DQ1 NRF_FUN_SDP_MSPI_DQ1
+/** High-Performance Framework MSPI data pin 2 */
+#define NRF_FUN_HPF_MSPI_DQ2 NRF_FUN_SDP_MSPI_DQ2
+/** High-Performance Framework MSPI data pin 3 */
+#define NRF_FUN_HPF_MSPI_DQ3 NRF_FUN_SDP_MSPI_DQ3
+/** High-Performance Framework MSPI data pin 4 */
+#define NRF_FUN_HPF_MSPI_DQ4 NRF_FUN_SDP_MSPI_DQ4
+/** High-Performance Framework MSPI data pin 5 */
+#define NRF_FUN_HPF_MSPI_DQ5 NRF_FUN_SDP_MSPI_DQ5
+/** High-Performance Framework MSPI data pin 6 */
+#define NRF_FUN_HPF_MSPI_DQ6 NRF_FUN_SDP_MSPI_DQ6
+/** High-Performance Framework MSPI data pin 7 */
+#define NRF_FUN_HPF_MSPI_DQ7 NRF_FUN_SDP_MSPI_DQ7
+/** High-Performance Framework MSPI chip select pin 0 */
+#define NRF_FUN_HPF_MSPI_CS0 NRF_FUN_SDP_MSPI_CS0
+/** High-Performance Framework MSPI chip select pin 1 */
+#define NRF_FUN_HPF_MSPI_CS1 NRF_FUN_SDP_MSPI_CS1
+/** High-Performance Framework MSPI chip select pin 2 */
+#define NRF_FUN_HPF_MSPI_CS2 NRF_FUN_SDP_MSPI_CS2
+/** High-Performance Framework MSPI chip select pin 3 */
+#define NRF_FUN_HPF_MSPI_CS3 NRF_FUN_SDP_MSPI_CS3
+/** High-Performance Framework MSPI chip select pin 4 */
+#define NRF_FUN_HPF_MSPI_CS4 NRF_FUN_SDP_MSPI_CS4
 /** TDM SCK in master mode */
 #define NRF_FUN_TDM_SCK_M        71U
 /** TDM SCK in slave mode */

--- a/subsys/sd/mmc.c
+++ b/subsys/sd/mmc.c
@@ -338,6 +338,14 @@ static inline void mmc_decode_csd(struct sd_csd *csd, uint32_t *raw_csd)
 	csd->file_fmt = (uint8_t)((raw_csd[0U] & 0x00000C00U) >> 10U);
 }
 
+static inline void mmc_set_clock(struct sd_card *card,
+				 enum sdhc_clock_speed card_clock_max,
+				 enum sdhc_timing_mode timing)
+{
+	card->bus_io.clock = MIN(card->host_props.f_max, card_clock_max);
+	card->bus_io.timing = timing;
+}
+
 static inline int mmc_set_max_freq(struct sd_card *card, struct sd_csd *card_csd)
 {
 	int ret;
@@ -346,13 +354,11 @@ static inline int mmc_set_max_freq(struct sd_card *card, struct sd_csd *card_csd
 
 	/* 4.3 - 5.1 emmc spec says 26 MHz */
 	if (frequency_code == MMC_MAXFREQ_10MHZ && multiplier_code == MMC_MAXFREQ_MULT_26) {
-		card->bus_io.clock = 26000000U;
-		card->bus_io.timing = SDHC_TIMING_LEGACY;
+		mmc_set_clock(card, 26000000U, SDHC_TIMING_LEGACY);
 	}
 	/* 4.0 - 4.2 emmc spec says 20 MHz */
 	else if (frequency_code == MMC_MAXFREQ_10MHZ && multiplier_code == MMC_MAXFREQ_MULT_20) {
-		card->bus_io.clock = 20000000U;
-		card->bus_io.timing = SDHC_TIMING_LEGACY;
+		mmc_set_clock(card, 20000000U, SDHC_TIMING_LEGACY);
 	} else {
 		LOG_INF("Using Legacy MMC will have slow initialization");
 		return 0;
@@ -422,8 +428,7 @@ static int mmc_set_hs_timing(struct sd_card *card)
 	sdmmc_wait_ready(card);
 
 	/* Max frequency in HS mode is 52 MHz */
-	card->bus_io.clock = MMC_CLOCK_52MHZ;
-	card->bus_io.timing = SDHC_TIMING_HS;
+	mmc_set_clock(card, MMC_CLOCK_52MHZ, SDHC_TIMING_HS);
 	/* Change SDHC bus timing */
 	ret = sdhc_set_io(card->sdhc, &card->bus_io);
 	if (ret) {
@@ -462,8 +467,7 @@ static int mmc_set_timing(struct sd_card *card, struct mmc_ext_csd *ext)
 			return ret;
 		}
 		cmd.arg = MMC_SWITCH_HS200_TIMING_ARG;
-		card->bus_io.clock = MMC_CLOCK_HS200;
-		card->bus_io.timing = SDHC_TIMING_HS200;
+		mmc_set_clock(card, MMC_CLOCK_HS200, SDHC_TIMING_HS200);
 	} else if (ext->device_type.MMC_HS_52_DV) {
 		return mmc_set_hs_timing(card);
 	} else if (ext->device_type.MMC_HS_26_DV) {
@@ -547,8 +551,7 @@ static int mmc_set_timing(struct sd_card *card, struct mmc_ext_csd *ext)
 			return ret;
 		}
 		/* Set SDHC bus io parameters */
-		card->bus_io.clock = MMC_CLOCK_HS400;
-		card->bus_io.timing = SDHC_TIMING_HS400;
+		mmc_set_clock(card, MMC_CLOCK_HS400, SDHC_TIMING_HS400);
 		ret = sdhc_set_io(card->sdhc, &card->bus_io);
 		if (ret) {
 			return ret;


### PR DESCRIPTION
- *[nrf fromtree] sd: mmc: Respect host limits when changing bus frequency* - this is an upstream fix required for successful SD stack initialization on nRF54L Series
- *[nrf noup] drivers: pinctrl_nrf: Add support for SDP/HPF pins]* - adds pinctrl SP_PIN function that is to be used with sEMMC and moves the "noup" parts of pinctrl code to minimize the risk of conflicts with further upstream changes