### PR TITLE
[cherry-pick] Support multiple CDC ACM instances

### DIFF
--- a/doc/connectivity/usb/device_next/cdc_acm.rst
+++ b/doc/connectivity/usb/device_next/cdc_acm.rst
@@ -1,0 +1,168 @@
+.. _usbd_cdc_acm:
+
+USB device CDC ACM
+##################
+
+The CDC ACM function provided by the USB device stack only implements Abstract
+Control Model Serial Emulation. Its sole purpose is to emulate serial lines, as
+its name suggests. Most modern operating systems should provide support
+for it out of the box.
+
+The CDC ACM function is represented as a serial interface on both the host and
+device sides, while the user or application interface is the :ref:`uart_api`
+driver API. This allows applications that already use the UART API to use the
+serial interface provided by the CDC ACM function without changing the code
+responsible for data communication. Only additional configuration and USB
+device stack initialization are required.
+
+CDC ACM UART configuration
+==========================
+
+Like the real UART controller, the virtual CDC ACM UART is described in the
+device tree. The devicetree compatible property for CDC ACM UART is
+:dtcompatible:`zephyr,cdc-acm-uart`.
+
+CDC ACM support is automatically selected when USB device support is enabled
+and a compatible node in the devicetree sources is present. If necessary, CDC ACM
+support can be explicitly disabled by :kconfig:option:`CONFIG_USBD_CDC_ACM_CLASS`.
+The number of possible CDC ACM instances depends on the number of supported
+endpoints on the USB device controller. Each CDC ACM instance requires three
+endpoints: two bulk endpoints (one IN, one OUT) and one interrupt IN with a
+MaxPacketSize of 16.
+The CDC ACM node can use the ``label`` property to distinguish different interfaces
+on the host side. Below is an example of the devicetree overlay file.
+
+.. code-block:: devicetree
+
+	&zephyr_udc0 {
+		cdc_acm_uart0: cdc_acm_uart0 {
+			compatible = "zephyr,cdc-acm-uart";
+			label = "CDC_ACM_0";
+		};
+	};
+
+Before the application uses CDC ACM UART, it may want to wait for the DTR
+signal. Please refer to :zephyr:code-sample:`usb-cdc-acm` on how to implement
+this functionality.
+
+.. note::
+  To communicate with the host, beside the UART configuration, the application
+  must enable USB device stack, for that please refer to
+  :ref:`usb_device_next_howto_configure` and read carefully the next chapter. For
+  users and applications migrating from the legacy stack, this is the only part
+  they need to adapt.
+
+.. _cdc_acm_uart_as_serial_backend:
+
+CDC ACM UART as serial backend
+==============================
+
+Using the example above and the ``zephyr,console`` chosen node property, you can
+configure the CDC ACM UART as the console device.
+
+.. code-block:: devicetree
+
+	/ {
+		chosen {
+			zephyr,console = &cdc_acm_uart0;
+		};
+	};
+
+	&zephyr_udc0 {
+		cdc_acm_uart0: cdc_acm_uart0 {
+			compatible = "zephyr,cdc-acm-uart";
+			label = "CDC_ACM_0";
+		};
+	};
+
+In the same way that the console in the above example is configured to use the
+CDC ACM UART, ``zephyr,shell-uart`` chosen node property can be used to
+configure the shell to use the CDC ACM UART as the serial backend. See sample
+:zephyr:code-sample:`shell-module` and :ref:`chosen nodes documentation
+<devicetree-chosen-nodes>`.
+
+Since the use case as a serial backend is very common and no configuration is
+necessary at runtime for the CDC ACM UART, the stack offers a helper that
+performs the steps described in :ref:`usb_device_next_howto_configure`. The
+helper is enabled by the :kconfig:option:`CONFIG_CDC_ACM_SERIAL_INITIALIZE_AT_BOOT`
+and initializes the USB device stack with a single CDC ACM instance. Sample
+:zephyr:code-sample:`usb-cdc-acm-console` demonstrates how to use it.
+
+:kconfig:option:`CONFIG_CDC_ACM_SERIAL_INITIALIZE_AT_BOOT` should also be used
+by the boards like :zephyr:board:`nrf52840dongle`, which do not have a debug
+adapter but a USB device controller, and want to use CDC ACM UART as default
+serial backend for logging and shell.
+As the configuration would be identical for any board, there are common
+:zephyr_file:`devicetree file <boards/common/usb/cdc_acm_serial.dtsi>` and
+:zephyr_file:`Kconfig file <boards/common/usb/Kconfig.cdc_acm_serial.defconfig>`
+that must be included in the board's devicetree and Kconfig.defconfig files.
+
+Using CDC ACM UART in the application
+=====================================
+
+CDC ACM implements a virtual UART controller and provides Interrupt-driven UART
+API and Polling UART API. The ASYNC API is not supported yet. If the
+application wants to communicate over CDC ACM UART, the preferable way is to
+use Interrupt-driven UART API. It is essential to understand API documentation,
+nevertheless, some notes below.
+
+Interrupt-driven UART API
+-------------------------
+
+Internally the CDC ACM UART implementation uses two ringbuffers. These take over the
+function of the TX/RX FIFOs (TX/RX buffers) from the :ref:`uart_interrupt_api`.
+
+As described in the :ref:`uart_interrupt_api`, the functions
+:c:func:`uart_irq_update()`, :c:func:`uart_irq_is_pending`,
+:c:func:`uart_irq_rx_ready()`, :c:func:`uart_irq_tx_ready()`
+:c:func:`uart_fifo_read()`, and :c:func:`uart_fifo_fill()`
+should be called from the interrupt handler, see
+:c:func:`uart_irq_callback_user_data_set()`. To prevent undefined behavior,
+the implementation of these functions checks in what context they are called
+and fails if it is not an interrupt handler.
+
+Also, as described in the UART API, :c:func:`uart_irq_is_pending`
+:c:func:`uart_irq_rx_ready()`, and :c:func:`uart_irq_tx_ready()`
+can only be called after :c:func:`uart_irq_update()`.
+
+Simplified, application interrupt handler should look something like:
+
+.. code-block:: c
+
+	static void interrupt_handler(const struct device *dev, void *user_data)
+	{
+		while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
+			if (uart_irq_rx_ready(dev)) {
+				int len;
+				int n;
+
+				/* ... */
+				n = uart_fifo_read(dev, buffer, len);
+				/* ... */
+			}
+
+			if (uart_irq_tx_ready(dev)) {
+				int len;
+				int n;
+
+				/* ... */
+				n = uart_fifo_fill(dev, buffer, len);
+			  /* ... */
+			}
+		}
+	}
+
+All these functions are not directly dependent on the status of the USB device.
+Filling the TX FIFO does not mean that data is being sent to the host. And
+successfully reading the RX FIFO does not mean that the device is still
+connected to the host. If there is space in the TX FIFO, and the TX interrupt
+is enabled, :c:func:`uart_irq_tx_ready()` will succeed. If there is data in the
+RX FIFO, and the RX interrupt is enabled, :c:func:`uart_irq_rx_ready()` will
+succeed. Function :c:func:`uart_irq_tx_complete()` is not implemented yet.
+
+Polling UART API
+----------------
+
+The CDC ACM poll out implementation follows :ref:`uart_polling_api` and
+blocks when the TX FIFO is full only if the hw-flow-control property is enabled
+and called from a non-ISR context.

--- a/doc/connectivity/usb/device_next/cdc_acm.rst
+++ b/doc/connectivity/usb/device_next/cdc_acm.rst
@@ -97,6 +97,15 @@ As the configuration would be identical for any board, there are common
 :zephyr_file:`Kconfig file <boards/common/usb/Kconfig.cdc_acm_serial.defconfig>`
 that must be included in the board's devicetree and Kconfig.defconfig files.
 
+Application can use :kconfig:option:`CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES`
+if different CDC ACM serial backends are required for common use cases such as
+logging, the shell, and specific protocols. This option also guarantees the
+order in which the instances will be registered and appear in the configuration
+descriptor. The option uses the chosen node properties to identify UART devices.
+The following are currently supported, in this order:
+"zephyr,console", "zephyr,shell-uart", "zephyr,uart-mcumgr".
+A supported property may be missing, and properties may reference the same device.
+
 Using CDC ACM UART in the application
 =====================================
 

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -46,6 +46,8 @@ Samples
   ``-DDEXTRA_CONF_FILE=overlay-usbd_next_ecm.conf`` and devicetree overlay file
   ``-DDTC_OVERLAY_FILE="usbd_next_ecm.overlay`` either directly or via ``west``.
 
+.. _usb_device_next_howto_configure:
+
 How to configure and enable USB device support
 **********************************************
 
@@ -217,69 +219,3 @@ instance (``n``) and is used as an argument to the :c:func:`usbd_register_class`
 +-----------------------------------+-------------------------+-------------------------+
 | USB Video Class (UVC)             | Video device            | :samp:`uvc_{n}`         |
 +-----------------------------------+-------------------------+-------------------------+
-
-CDC ACM UART
-============
-
-CDC ACM implements a virtual UART controller and provides Interrupt-driven UART
-API and Polling UART API.
-
-Interrupt-driven UART API
--------------------------
-
-Internally the implementation uses two ringbuffers, these take over the
-function of the TX/RX FIFOs (TX/RX buffers) from the :ref:`uart_interrupt_api`.
-
-As described in the :ref:`uart_interrupt_api`, the functions
-:c:func:`uart_irq_update()`, :c:func:`uart_irq_is_pending`,
-:c:func:`uart_irq_rx_ready()`, :c:func:`uart_irq_tx_ready()`
-:c:func:`uart_fifo_read()`, and :c:func:`uart_fifo_fill()`
-should be called from the interrupt handler, see
-:c:func:`uart_irq_callback_user_data_set()`. To prevent undefined behaviour,
-the implementation of these functions checks in what context they are called
-and fails if it is not an interrupt handler.
-
-Also, as described in the UART API, :c:func:`uart_irq_is_pending`
-:c:func:`uart_irq_rx_ready()`, and :c:func:`uart_irq_tx_ready()`
-can only be called after :c:func:`uart_irq_update()`.
-
-Simplified, the interrupt handler should look something like:
-
-.. code-block:: c
-
-   static void interrupt_handler(const struct device *dev, void *user_data)
-   {
-      while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
-         if (uart_irq_rx_ready(dev)) {
-            int len;
-            int n;
-
-            /* ... */
-            n = uart_fifo_read(dev, buffer, len);
-            /* ... */
-         }
-
-         if (uart_irq_tx_ready(dev)) {
-            int len;
-            int n;
-
-            /* ... */
-            n = uart_fifo_fill(dev, buffer, len);
-           /* ... */
-         }
-   }
-
-All these functions are not directly dependent on the status of the USB device.
-Filling the TX FIFO does not mean that data is being sent to the host. And
-successfully reading the RX FIFO does not mean that the device is still
-connected to the host. If there is space in the TX FIFO, and the TX interrupt
-is enabled, :c:func:`uart_irq_tx_ready()` will succeed. If there is data in the
-RX FIFO, and the RX interrupt is enabled, :c:func:`uart_irq_rx_ready()` will
-succeed. Function :c:func:`uart_irq_tx_complete()` is not implemented yet.
-
-Polling UART API
-----------------
-
-The CDC ACM poll out implementation follows :ref:`uart_polling_api` and
-blocks when the TX FIFO is full only if the hw-flow-control property is enabled
-and called from a non-ISR context.

--- a/doc/connectivity/usb/index.rst
+++ b/doc/connectivity/usb/index.rst
@@ -18,6 +18,7 @@ USB
 
    device_next/usb_device.rst
    device_next/vid_pid.rst
+   device_next/cdc_acm.rst
    device_next/api/index.rst
    host/api/index.rst
    host/usbip.rst

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -853,6 +853,8 @@ int usbd_add_configuration(struct usbd_context *uds_ctx,
  * @param[in] cfg     Configuration value (bConfigurationValue)
  *
  * @return 0 on success, other values on fail.
+ * @retval -EALREADY If class instance is already registered.
+ * @retval -EBUSY If USB device support is already initialized.
  */
 int usbd_register_class(struct usbd_context *uds_ctx,
 			const char *name,

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -16,3 +16,6 @@ common:
     - mimxrt1060_evk/mimxrt1062/qspi
 tests:
   sample.usbd.console: {}
+  sample.usbd.console.multiple-instances:
+    extra_configs:
+      - CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES=y

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -1,17 +1,18 @@
 sample:
   name: Console over CDC ACM serial
+common:
+  depends_on:
+    - usbd
+  tags: usb
+  harness: console
+  harness_config:
+    fixture: fixture_usb_cdc
+  integration_platforms:
+    - nrf52840dk/nrf52840
+    - frdm_k64f
+    - stm32f723e_disco
+    - nucleo_f413zh
+    - mimxrt685_evk/mimxrt685s/cm33
+    - mimxrt1060_evk/mimxrt1062/qspi
 tests:
-  sample.usbd.console:
-    depends_on:
-      - usbd
-    tags: usb
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - frdm_k64f
-      - stm32f723e_disco
-      - nucleo_f413zh
-      - mimxrt685_evk/mimxrt685s/cm33
-      - mimxrt1060_evk/mimxrt1062/qspi
-    harness: console
-    harness_config:
-      fixture: fixture_usb_cdc
+  sample.usbd.console: {}

--- a/subsys/usb/device_next/app/Kconfig.cdc_acm_serial
+++ b/subsys/usb/device_next/app/Kconfig.cdc_acm_serial
@@ -23,6 +23,19 @@ config CDC_ACM_SERIAL_ENABLE_AT_BOOT
 	  When disabled, the application is responsible for enabling/disabling
 	  the USB device.
 
+config CDC_ACM_SERIAL_MULTIPLE_INSTANCES
+	bool "Register and initialize multiple CDC ACM instances"
+	help
+	  Register multiple CDC ACM instances whose UARTs are referenced by
+	  appropriate Zephyr-specific chosen node properties. The order in which
+	  the instances will be registered and appear in the configuration
+	  descriptor is guaranteed. The following are currently supported, in
+	  this order: "zephyr,console", "zephyr,shell-uart", "zephyr,uart-mcumgr".
+	  A supported property may be missing, and properties may reference the
+	  same device.
+	  Each instance occupies two IN endpoints and one OUT endpoint. USB device
+	  controller must have enough resources to support multiple instances.
+
 config CDC_ACM_SERIAL_MANUFACTURER_STRING
 	string "USB device manufacturer string descriptor"
 	default "Zephyr Project"

--- a/subsys/usb/device_next/app/cdc_acm_serial.c
+++ b/subsys/usb/device_next/app/cdc_acm_serial.c
@@ -43,9 +43,69 @@ USBD_CONFIGURATION_DEFINE(cdc_acm_serial_hs_config,
 			  attributes,
 			  CONFIG_CDC_ACM_SERIAL_MAX_POWER, &hs_cfg_desc);
 
+/*
+ * The CDC ACM instances are registered in the same order that they appear in
+ * this array. Therefore, they are always presented in the same order on the
+ * host side. Add new entries at the end.
+ */
+const static struct device *uart_devs[] = {
+	DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_console)),
+	DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_shell_uart)),
+	DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_uart_mcumgr)),
+};
 
-static int register_cdc_acm_0(struct usbd_context *const uds_ctx,
-			      const enum usbd_speed speed)
+/*
+ * The class data stores a reference to the implemented UART device for
+ * internal purposes. Iterate over all class instances and compare the dev
+ * parameter with the referenced UART device. Then, try to register the
+ * instance. If multiple chosen node properties reference the same device,
+ * usbd_register_class() will fail with -EALREADY.
+ */
+static int register_chosen(struct usbd_context *const uds_ctx,
+			   const enum usbd_speed speed,
+			   const struct device *const dev)
+{
+	int err;
+
+	if (speed == USBD_SPEED_HS) {
+		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_hs, usbd_class_node, c_nd) {
+			struct usbd_class_data *c_data = c_nd->c_data;
+
+			if (usbd_class_get_private(c_data) == dev) {
+				err = usbd_register_class(&cdc_acm_serial,
+							  c_data->name, speed, 1);
+				if (err != 0 && err != -EALREADY) {
+					LOG_ERR("Failed to register %s", c_data->name);
+					return err;
+				}
+
+				break;
+			}
+		}
+	}
+
+	if (speed == USBD_SPEED_FS) {
+		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_fs, usbd_class_node, c_nd) {
+			struct usbd_class_data *c_data = c_nd->c_data;
+
+			if (usbd_class_get_private(c_data) == dev) {
+				err = usbd_register_class(&cdc_acm_serial,
+							  c_data->name, speed, 1);
+				if (err != 0 && err != -EALREADY) {
+					LOG_ERR("Failed to register %s", c_data->name);
+					return err;
+				}
+
+				break;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int register_cdc_acm(struct usbd_context *const uds_ctx,
+			    const enum usbd_speed speed)
 {
 	struct usbd_config_node *cfg_nd;
 	int err;
@@ -62,10 +122,28 @@ static int register_cdc_acm_0(struct usbd_context *const uds_ctx,
 		return err;
 	}
 
-	err = usbd_register_class(&cdc_acm_serial, "cdc_acm_0", speed, 1);
-	if (err) {
-		LOG_ERR("Failed to register classes");
-		return err;
+	if (IS_ENABLED(CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES)) {
+		for (int n = 0; n < ARRAY_SIZE(uart_devs); n++) {
+			if (uart_devs[n] == NULL) {
+				continue;
+			}
+
+			err = register_chosen(uds_ctx, speed, uart_devs[n]);
+			if (err) {
+				return err;
+			}
+		}
+	} else {
+		/*
+		 * Only register the first instance to maintain the legacy
+		 * stack behavior when using CDC ACM as a serial backend for
+		 * different applications.
+		 */
+		err = usbd_register_class(&cdc_acm_serial, "cdc_acm_0", speed, 1);
+		if (err) {
+			LOG_ERR("Failed to register %s", "cdc_acm_0");
+			return err;
+		}
 	}
 
 	return usbd_device_set_code_triple(uds_ctx, speed,
@@ -105,13 +183,13 @@ static int cdc_acm_serial_init_device(void)
 
 	if (USBD_SUPPORTS_HIGH_SPEED &&
 	    usbd_caps_speed(&cdc_acm_serial) == USBD_SPEED_HS) {
-		err = register_cdc_acm_0(&cdc_acm_serial, USBD_SPEED_HS);
+		err = register_cdc_acm(&cdc_acm_serial, USBD_SPEED_HS);
 		if (err) {
 			return err;
 		}
 	}
 
-	err = register_cdc_acm_0(&cdc_acm_serial, USBD_SPEED_FS);
+	err = register_cdc_acm(&cdc_acm_serial, USBD_SPEED_FS);
 	if (err) {
 		return err;
 	}

--- a/subsys/usb/device_next/usbd_class.c
+++ b/subsys/usb/device_next/usbd_class.c
@@ -319,13 +319,13 @@ int usbd_register_class(struct usbd_context *const uds_ctx,
 	/* TODO: does it still need to be atomic ? */
 	if (atomic_test_bit(&c_nd->state, USBD_CCTX_REGISTERED)) {
 		LOG_WRN("Class instance already registered");
-		ret = -EBUSY;
+		ret = -EALREADY;
 		goto register_class_error;
 	}
 
 	if ((c_data->uds_ctx != NULL) && (c_data->uds_ctx != uds_ctx)) {
 		LOG_ERR("Class registered to other context at different speed");
-		ret = -EBUSY;
+		ret = -EALREADY;
 		goto register_class_error;
 	}
 


### PR DESCRIPTION
Cherry-pick ongoing Zephyr PR that adds the support for multiple CDC ACM interfaces.
This is needed to develop applications for nRF54LM20 Dongle.