### PR TITLE
wifi: hostap: fix PEAP/TTLS enterprise auth failure by skipping client cert/key loading

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1008,31 +1008,38 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				}
 			}
 
-			if (wpas_config_process_blob(wpa_s->conf, "client_cert",
-					   enterprise_creds.client_cert,
-					   enterprise_creds.client_cert_len)) {
-				goto out;
-			}
+			/* Skip client cert/key for PEAP/TTLS - these methods
+			 * use only server-side certs. Sending a client cert
+			 * causes RADIUS servers (e.g. NPS) to reject PEAP.
+			 */
+			if (params->security != WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2 &&
+			    params->security != WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2) {
+				if (wpas_config_process_blob(wpa_s->conf, "client_cert",
+						   enterprise_creds.client_cert,
+						   enterprise_creds.client_cert_len)) {
+					goto out;
+				}
 
-			if (!wpa_cli_cmd_v("set_network %d client_cert \"blob://client_cert\"",
-					   resp.network_id)) {
-				goto out;
-			}
+				if (!wpa_cli_cmd_v("set_network %d client_cert \"blob://client_cert\"",
+						   resp.network_id)) {
+					goto out;
+				}
 
-			if (wpas_config_process_blob(wpa_s->conf, "private_key",
-					   enterprise_creds.client_key,
-					   enterprise_creds.client_key_len)) {
-				goto out;
-			}
+				if (wpas_config_process_blob(wpa_s->conf, "private_key",
+						   enterprise_creds.client_key,
+						   enterprise_creds.client_key_len)) {
+					goto out;
+				}
 
-			if (!wpa_cli_cmd_v("set_network %d private_key \"blob://private_key\"",
-					   resp.network_id)) {
-				goto out;
-			}
+				if (!wpa_cli_cmd_v("set_network %d private_key \"blob://private_key\"",
+						   resp.network_id)) {
+					goto out;
+				}
 
-			if (!wpa_cli_cmd_v("set_network %d private_key_passwd \"%s\"",
-					   resp.network_id, params->key_passwd)) {
-				goto out;
+				if (!wpa_cli_cmd_v("set_network %d private_key_passwd \"%s\"",
+						   resp.network_id, params->key_passwd)) {
+					goto out;
+				}
 			}
 
 			if (wpas_config_process_blob(wpa_s->conf, "ca_cert2",
@@ -1046,31 +1053,34 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				goto out;
 			}
 
-			if (wpas_config_process_blob(wpa_s->conf, "client_cert2",
-						     enterprise_creds.client_cert2,
-						     enterprise_creds.client_cert2_len)) {
-				goto out;
-			}
+			if (params->security != WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2 &&
+			    params->security != WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2) {
+				if (wpas_config_process_blob(wpa_s->conf, "client_cert2",
+							     enterprise_creds.client_cert2,
+							     enterprise_creds.client_cert2_len)) {
+					goto out;
+				}
 
-			if (!wpa_cli_cmd_v("set_network %d client_cert2 \"blob://client_cert2\"",
-					   resp.network_id)) {
-				goto out;
-			}
+				if (!wpa_cli_cmd_v("set_network %d client_cert2 \"blob://client_cert2\"",
+						   resp.network_id)) {
+					goto out;
+				}
 
-			if (wpas_config_process_blob(wpa_s->conf, "private_key2",
-						     enterprise_creds.client_key2,
-						     enterprise_creds.client_key2_len)) {
-				goto out;
-			}
+				if (wpas_config_process_blob(wpa_s->conf, "private_key2",
+							     enterprise_creds.client_key2,
+							     enterprise_creds.client_key2_len)) {
+					goto out;
+				}
 
-			if (!wpa_cli_cmd_v("set_network %d private_key2 \"blob://private_key2\"",
-					   resp.network_id)) {
-				goto out;
-			}
+				if (!wpa_cli_cmd_v("set_network %d private_key2 \"blob://private_key2\"",
+						   resp.network_id)) {
+					goto out;
+				}
 
-			if (!wpa_cli_cmd_v("set_network %d private_key2_passwd \"%s\"",
-					   resp.network_id, params->key2_passwd)) {
-				goto out;
+				if (!wpa_cli_cmd_v("set_network %d private_key2_passwd \"%s\"",
+						   resp.network_id, params->key2_passwd)) {
+					goto out;
+				}
 			}
 #endif
 		} else {


### PR DESCRIPTION
EAP-PEAP and EAP-TTLS use server-side TLS only (Phase 1) and authenticate
the client via username/password in Phase 2 (MSCHAPv2). Loading client_cert
and private_key blobs for these methods causes mbedTLS to present a client
certificate during the TLS handshake. RADIUS servers (e.g. Microsoft NPS)
reject the unexpected certificate, sending EAP-Failure before Phase 2 begins.

Per RFC 5281 (EAP-TTLS) Section 7.6 and PEAPv0, a client without a
certificate should respond with an empty Certificate message, allowing the
server to proceed to Phase 2 for password-based authentication.

Wrap client_cert, private_key, and private_key_passwd blob loading (Phase 1
and Phase 2) in a conditional that skips them for
WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2 and
WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2. CA cert loading is unaffected.
EAP-TLS (mutual cert authentication) is unaffected.

The skip condition is scoped specifically to the MSCHAPV2 security type
enums. These enums explicitly indicate a password-based inner method, which
does not require client certificates. If Zephyr adds future security types
with certificate-based inner methods (e.g. EAP-PEAP with EAP-TLS inner),
those would use different enum values and would not match the skip condition.

Tested on nRF7002DK with WPA2-Enterprise PEAP-MSCHAPv2 against Microsoft
NPS RADIUS server. Verified EAP-TLS still works (regression check).