### PR TITLE
[nrf fromlist] cmake: modules: move DTC_OVERLAY_FILE boilerplate watch

### DIFF
--- a/cmake/modules/configuration_files.cmake
+++ b/cmake/modules/configuration_files.cmake
@@ -89,9 +89,6 @@ alternate .overlay file using this parameter. These settings will override the \
 settings in the board's .dts file. Multiple files may be listed, e.g. \
 DTC_OVERLAY_FILE=\"dts1.overlay dts2.overlay\"")
 
-# The DTC_OVERLAY_FILE variable is now set to its final value.
-zephyr_boilerplate_watch(DTC_OVERLAY_FILE)
-
 zephyr_get(EXTRA_CONF_FILE SYSBUILD LOCAL VAR EXTRA_CONF_FILE OVERLAY_CONFIG MERGE REVERSE)
 zephyr_get(EXTRA_DTC_OVERLAY_FILE SYSBUILD LOCAL MERGE REVERSE)
 zephyr_get(DTS_EXTRA_CPPFLAGS SYSBUILD LOCAL MERGE REVERSE)

--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -184,6 +184,9 @@ set(dts_files
   ${shield_dts_files}
   )
 
+# Guard DTC_OVERLAY_FILE as it will now be consumed and should no longer be changed.
+zephyr_boilerplate_watch(DTC_OVERLAY_FILE)
+
 if(DTC_OVERLAY_FILE)
   zephyr_list(TRANSFORM DTC_OVERLAY_FILE NORMALIZE_PATHS
               OUTPUT_VARIABLE DTC_OVERLAY_FILE_AS_LIST)


### PR DESCRIPTION
Move the zephyr_boilerplate_watch() call for DTC_OVERLAY_FILE from configuration_files.cmake to dts.cmake so that it fires right before the variable is consumed rather than right after it was configured automatically.

This avoids false warnings when DTC_OVERLAY_FILE is modified after the automatic configuration.

Upstream PR #:106193