### PR TITLE
[nrf noup] Exchange CRACEN_LIB_KMU with CRACEN_KMU KConfig option

### DIFF
--- a/tests/application_development/ram_context_for_isr/boards/nrf54l05dk_nrf54l05_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54l05dk_nrf54l05_cpuapp.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_CRACEN_LIB_KMU=n
+CONFIG_CRACEN_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_CRACEN_LIB_KMU=n
+CONFIG_CRACEN_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_CRACEN_LIB_KMU=n
+CONFIG_CRACEN_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_CRACEN_LIB_KMU=n
+CONFIG_CRACEN_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_CRACEN_LIB_KMU=n
+CONFIG_CRACEN_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_CRACEN_LIB_KMU=n
+CONFIG_CRACEN_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf7120pdk_nrf7120_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf7120pdk_nrf7120_cpuapp.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-CONFIG_CRACEN_LIB_KMU=n
+CONFIG_CRACEN_KMU=n


### PR DESCRIPTION
Changing CRACEN_LIB_KMU Kconfig option to CRACEN_KMU since LIB_KMU is exchanged with NRFX KMU driver.