### PR TITLE
[nrf noup] ci: Extend test spec for Bluetooth to cover nrf_grtc_timer

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -96,6 +96,8 @@
   - any:
       - "drivers/bluetooth/**/*"
       - "drivers/clock_control/**/*"
+      - "drivers/timer/Kconfig.nrf_grtc"
+      - "drivers/timer/nrf_grtc_timer.c"
   - any:
       - "dts/arm/nordic/nrf5*"
   - any:
@@ -105,6 +107,7 @@
   - any:
       - "include/zephyr/bluetooth/**/*"
       - "!include/zephyr/bluetooth/mesh/**/*"
+      - "include/zephyr/drivers/timer/nrf_grtc_timer.h"
   - any:
       - "boards/nordic/nrf5*"
   - any:


### PR DESCRIPTION
The Bluetooth stack depends on correct configuration and behavior of the GRTC system timer. Misconfiguration or incorrect handling can affect stack behavior.

Add BLE tests to the required plans so regressions in this area are caught.