### PR TITLE
[nrf fromlist] modules: hal_nordic: ironside: fix IRONSIDE_SUPPORT_DI…

### DIFF
--- a/modules/hal_nordic/ironside/se/CMakeLists.txt
+++ b/modules/hal_nordic/ironside/se/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-include(./ironside_support_dir.cmake)
+if(EXISTS ${ZEPHYR_HAL_NORDIC_CMAKE_DIR}/ironside/se/ironside_support_dir.cmake)
+  include(${ZEPHYR_HAL_NORDIC_CMAKE_DIR}/ironside/se/ironside_support_dir.cmake)
+else()
+  include(${ZEPHYR_BASE}/modules/hal_nordic/ironside/se/ironside_support_dir.cmake)
+endif()
 
 zephyr_include_directories(include)
 zephyr_include_directories(${IRONSIDE_SUPPORT_DIR}/se/include)

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -18,7 +18,11 @@ find_package(Zephyr
   )
 
 # Needed since the CMakeLists.txt that would normally set this is not run in this image.
-include(${ZEPHYR_BASE}/modules/hal_nordic/ironside/se/ironside_support_dir.cmake)
+if(EXISTS ${ZEPHYR_HAL_NORDIC_CMAKE_DIR}/ironside/se/ironside_support_dir.cmake)
+  include(${ZEPHYR_HAL_NORDIC_CMAKE_DIR}/ironside/se/ironside_support_dir.cmake)
+else()
+  include(${ZEPHYR_BASE}/modules/hal_nordic/ironside/se/ironside_support_dir.cmake)
+endif()
 
 project(uicr)
 


### PR DESCRIPTION
…R override

Upstream PR #: 106689

Overriding the IRONSIDE_SUPPORT_DIR location did not work as intended. Fix the issue by updating the includes of ironside_support_dir.cmake to use the ZEPHYR_HAL_NORDIC_CMAKE_DIR variable to determine the base path containing the .cmake file.