### PR TITLE
[nrf fromlist] drivers: mbox: nrf: retrigger VEVIF task TX on nRF54LM20

### DIFF
--- a/drivers/mbox/mbox_nrf_vevif_task_tx.c
+++ b/drivers/mbox/mbox_nrf_vevif_task_tx.c
@@ -41,11 +41,11 @@ static int vevif_task_tx_send(const struct device *dev, uint32_t id, const struc
 
 	nrfy_vpr_task_trigger(config->vpr, nrfy_vpr_trigger_task_get(id));
 
-#ifdef CONFIG_SOC_NRF54H20
+#if defined(CONFIG_SOC_NRF54H20) || defined(CONFIG_SOC_NRF54LM20A) || defined(CONFIG_SOC_NRF54LM20B)
 	k_busy_wait(VEVIF_RETRIGGER_DELAY_USEC);
 
 	nrfy_vpr_task_trigger(config->vpr, nrfy_vpr_trigger_task_get(id));
-#endif /* CONFIG_SOC_NRF54H20 */
+#endif /* CONFIG_SOC_NRF54H20 || CONFIG_SOC_NRF54LM20A || CONFIG_SOC_NRF54LM20B */
 
 	return 0;
 }


### PR DESCRIPTION
Back-to-back VEVIF task notifications on nRF54L could be collapsed into a single observed event, which caused the second mailbox packet to be missed by the remote side. Extend the existing delayed retrigger workaround used on nRF54H20 so task-based mailbox sends are delivered reliably on nRF54LM20 as well.

Upstream PR #: [106782](https://github.com/zephyrproject-rtos/zephyr/pull/106782)

manifest-pr-skip