### PR TITLE
[nrf fromlist] drivers: hwinfo: nrf: Enable driver for nRF92

### DIFF
--- a/drivers/hwinfo/Kconfig.nrf
+++ b/drivers/hwinfo/Kconfig.nrf
@@ -5,7 +5,7 @@ config HWINFO_NRF
 	bool "NRF device ID"
 	default y
 	depends on SOC_FAMILY_NORDIC_NRF
-	depends on SOC_SERIES_NRF54H || NRF_SOC_SECURE_SUPPORTED
+	depends on SOC_SERIES_NRF54H || SOC_SERIES_NRF92 || NRF_SOC_SECURE_SUPPORTED
 	select HWINFO_HAS_DRIVER
 	help
 	  Enable Nordic NRF hwinfo driver.

--- a/drivers/hwinfo/hwinfo_nrf.c
+++ b/drivers/hwinfo/hwinfo_nrf.c
@@ -52,6 +52,13 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 	 */
 	buf[1] |= (nrf_ficr_er_get(NRF_FICR, 0) & 0xFF) << 16;
 	buf[1] |= (nrf_ficr_ir_get(NRF_FICR, 0) & 0xFF) << 24;
+#elif NRF_FICR_HAS_NFC_TAGHEADER_ARRAY
+	/* DEVICEID is not accessible, use NFCID instead.
+	 * Assume that it is always accessible from the non-secure image.
+	 * Skip TAGHEADER[0] as it always contain Manufacturer ID.
+	 */
+	buf[0] = nrf_ficr_nfc_tagheader_get(NRF_FICR, 1);
+	buf[1] = nrf_ficr_nfc_tagheader_get(NRF_FICR, 2);
 #else
 #error "No suitable source for hwinfo device_id generation"
 #endif


### PR DESCRIPTION
Added support for hwinfo_nrf driver for nRF92 series.

This change is required for nRF9251dk support.

Upstream PR #: 107038