### PR TITLE
[nrf noup] manifest: update hal_nordic revision

### DIFF
--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -71,6 +71,14 @@ function(compute_optional_partition_address_and_size partition_nodelabel output_
   endif()
 endfunction()
 
+set(IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE "")
+
+if(CONFIG_SOC_NRF54H20)
+  set(IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE
+    "${IRONSIDE_SUPPORT_DIR}/se/resources/periphconf_registers-nrf54h20_xxaa-v23.4.0+27.json"
+  )
+endif()
+
 # Use CMAKE_VERBOSE_MAKEFILE to silence an unused-variable warning.
 if(CMAKE_VERBOSE_MAKEFILE)
 endif()
@@ -356,6 +364,70 @@ if(CONFIG_GEN_UICR_POLICY_MPCCONF_STAGE_INIT OR CONFIG_GEN_UICR_POLICY_MPCCONF_S
   list(APPEND policy_args --policy-mpcconf-stage ${CONFIG_GEN_UICR_POLICY_MPCCONF_STAGE_VALUE})
 endif()
 
+set(periphconf_check_base_cmd
+  ${CMAKE_COMMAND} -E env ZEPHYR_BASE=${ZEPHYR_BASE}
+  ${PYTHON_EXECUTABLE} ${IRONSIDE_SUPPORT_DIR}/se/tool/ironside/__main__.py
+  periphconf-check
+  --in-periphconf-registers-json ${IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE}
+)
+
+set(periphconf_validate_command)
+set(secondary_periphconf_validate_command)
+
+if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF AND IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE)
+  set(check_cmd ${periphconf_check_base_cmd} --in-periphconf-hex ${periphconf_hex_file})
+
+  set(periphconf_validate_build_command
+    COMMAND ${check_cmd} --mode errors
+  )
+
+  add_custom_target(
+    periphconf_validate
+    COMMAND ${check_cmd} --mode errors
+    DEPENDS ${periphconf_hex_file}
+    COMMENT "Validating ${periphconf_hex_file}"
+  )
+  add_custom_target(
+    periphconf_dump
+    COMMAND ${check_cmd} --mode full
+    DEPENDS ${periphconf_hex_file}
+    COMMENT "Printing ${periphconf_hex_file}"
+  )
+  add_custom_target(
+    periphconf_dump_raw
+    COMMAND ${check_cmd} --mode full --style raw
+    DEPENDS ${periphconf_hex_file}
+    COMMENT "Printing ${periphconf_hex_file}"
+  )
+endif()
+
+if(CONFIG_GEN_UICR_SECONDARY_GENERATE_PERIPHCONF AND IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE)
+  set(check_cmd ${periphconf_check_base_cmd} --in-periphconf-hex ${secondary_periphconf_hex_file})
+
+  set(secondary_periphconf_validate_build_command
+    COMMAND ${check_cmd} --mode errors
+  )
+
+  add_custom_target(
+    secondary_periphconf_validate
+    COMMAND ${check_cmd} --mode errors
+    DEPENDS ${secondary_periphconf_hex_file}
+    COMMENT "Validating ${secondary_periphconf_hex_file}"
+  )
+  add_custom_target(
+    secondary_periphconf_dump
+    COMMAND ${check_cmd} --mode full
+    DEPENDS ${secondary_periphconf_hex_file}
+    COMMENT "Printing ${secondary_periphconf_hex_file}"
+  )
+  add_custom_target(
+    secondary_periphconf_dump_raw
+    COMMAND ${check_cmd} --mode full --style raw
+    DEPENDS ${secondary_periphconf_hex_file}
+    COMMENT "Printing ${secondary_periphconf_hex_file}"
+  )
+endif()
+
 add_custom_command(
   OUTPUT ${gen_uicr_outputs}
   COMMAND ${PYTHON_EXECUTABLE} ${IRONSIDE_SUPPORT_DIR}/se/tool/ironside/__main__.py
@@ -376,6 +448,8 @@ add_custom_command(
           ${protectedmem_args}
           ${secondary_args}
           ${policy_args}
+  ${periphconf_validate_build_command}
+  ${secondary_periphconf_validate_build_command}
   DEPENDS ${gen_uicr_depends}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   COMMENT "Generating UICR artifacts"

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -71,14 +71,6 @@ function(compute_optional_partition_address_and_size partition_nodelabel output_
   endif()
 endfunction()
 
-set(IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE "")
-
-if(CONFIG_SOC_NRF54H20)
-  set(IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE
-    "${IRONSIDE_SUPPORT_DIR}/se/resources/periphconf_registers-nrf54h20_xxaa-v23.4.0+27.json"
-  )
-endif()
-
 # Use CMAKE_VERBOSE_MAKEFILE to silence an unused-variable warning.
 if(CMAKE_VERBOSE_MAKEFILE)
 endif()
@@ -364,70 +356,6 @@ if(CONFIG_GEN_UICR_POLICY_MPCCONF_STAGE_INIT OR CONFIG_GEN_UICR_POLICY_MPCCONF_S
   list(APPEND policy_args --policy-mpcconf-stage ${CONFIG_GEN_UICR_POLICY_MPCCONF_STAGE_VALUE})
 endif()
 
-set(periphconf_check_base_cmd
-  ${CMAKE_COMMAND} -E env ZEPHYR_BASE=${ZEPHYR_BASE}
-  ${PYTHON_EXECUTABLE} ${IRONSIDE_SUPPORT_DIR}/se/tool/ironside/__main__.py
-  periphconf-check
-  --in-periphconf-registers-json ${IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE}
-)
-
-set(periphconf_validate_command)
-set(secondary_periphconf_validate_command)
-
-if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF AND IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE)
-  set(check_cmd ${periphconf_check_base_cmd} --in-periphconf-hex ${periphconf_hex_file})
-
-  set(periphconf_validate_build_command
-    COMMAND ${check_cmd} --mode errors
-  )
-
-  add_custom_target(
-    periphconf_validate
-    COMMAND ${check_cmd} --mode errors
-    DEPENDS ${periphconf_hex_file}
-    COMMENT "Validating ${periphconf_hex_file}"
-  )
-  add_custom_target(
-    periphconf_dump
-    COMMAND ${check_cmd} --mode full
-    DEPENDS ${periphconf_hex_file}
-    COMMENT "Printing ${periphconf_hex_file}"
-  )
-  add_custom_target(
-    periphconf_dump_raw
-    COMMAND ${check_cmd} --mode full --style raw
-    DEPENDS ${periphconf_hex_file}
-    COMMENT "Printing ${periphconf_hex_file}"
-  )
-endif()
-
-if(CONFIG_GEN_UICR_GENERATE_SECONDARY_PERIPHCONF AND IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE)
-  set(check_cmd ${periphconf_check_base_cmd} --in-periphconf-hex ${secondary_periphconf_hex_file})
-
-  set(secondary_periphconf_validate_build_command
-    COMMAND ${check_cmd} --mode errors
-  )
-
-  add_custom_target(
-    secondary_periphconf_validate
-    COMMAND ${check_cmd} --mode errors
-    DEPENDS ${secondary_periphconf_hex_file}
-    COMMENT "Validating ${secondary_periphconf_hex_file}"
-  )
-  add_custom_target(
-    secondary_periphconf_dump
-    COMMAND ${check_cmd} --mode full
-    DEPENDS ${secondary_periphconf_hex_file}
-    COMMENT "Printing ${secondary_periphconf_hex_file}"
-  )
-  add_custom_target(
-    secondary_periphconf_dump_raw
-    COMMAND ${check_cmd} --mode full --style raw
-    DEPENDS ${secondary_periphconf_hex_file}
-    COMMENT "Printing ${secondary_periphconf_hex_file}"
-  )
-endif()
-
 add_custom_command(
   OUTPUT ${gen_uicr_outputs}
   COMMAND ${PYTHON_EXECUTABLE} ${IRONSIDE_SUPPORT_DIR}/se/tool/ironside/__main__.py
@@ -448,8 +376,6 @@ add_custom_command(
           ${protectedmem_args}
           ${secondary_args}
           ${policy_args}
-  ${periphconf_validate_build_command}
-  ${secondary_periphconf_validate_build_command}
   DEPENDS ${gen_uicr_depends}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   COMMENT "Generating UICR artifacts"

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 7142bc9c3c94f06e3b520890dde93d363c0e67bf
+      revision: 1acb428a205bad58f3dfd4e38f2d1663bb784ba1
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Noup due to conflicts.

Pull in a bugfix to the error print in the PERIPHCONF validation script when two or more inputs were given.
Also cherry pick a fromlist commit again to fix a typo in a Kconfig.