### PR TITLE
[Backport ncs-v3.3-branch] [nrf fromlist] snippets: wifi-credentials: Fix the heading

### DIFF
--- a/snippets/wifi/wifi-credentials/README.rst
+++ b/snippets/wifi/wifi-credentials/README.rst
@@ -1,7 +1,7 @@
 .. _snippet-wifi-credentials:
 
-Wi-Fi Credentials Snippet (wifi-credential)
-###########################################
+Wi-Fi Credentials Snippet (wifi-credentials)
+############################################
 
 .. code-block:: console
 


### PR DESCRIPTION
Backport c6863fca5073cb733110b8490918f408bbfa6884 from #3972.