### PR TITLE
soc: nordic: gen_uicr: Add support to add CUSTOMER hex file

### DIFF
--- a/modules/hal_nordic/ironside/se/support_package/ironside/se/tool/ironside/commands/gen_uicr.py
+++ b/modules/hal_nordic/ironside/se/support_package/ironside/se/tool/ironside/commands/gen_uicr.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import ctypes as c
 import sys
+from pathlib import Path
 from itertools import groupby, pairwise
 from typing import NamedTuple
 
@@ -705,6 +706,18 @@ def add_parser(subparsers: SubParsers) -> argparse.ArgumentParser:
             "Setting this to Initialization updates the UICR minimum version to 2.2"
         ),
     )
+    parser.add_argument(
+        "--in-customer-hex",
+        dest="in_customer_hex",
+        default="",
+        # type=argparse.FileType("r"), # Dont need to open file, so no need in this
+        help="Path to an HEX file containing CUSTOMER data.",
+    )
+    parser.add_argument(
+        "--out-customer-hex",
+        type=argparse.FileType("w", encoding="utf-8"),
+        help="Path to write the CUSTOMER-only HEX file to",
+    )
 
     return parser
 
@@ -785,6 +798,9 @@ def cmd_handler(args: argparse.Namespace) -> None:
 
         if len(args.in_secondary_mpcconf_elfs) > 1:
             raise ScriptError("currently only one --in-secondary-mpcconf-elf argument is supported")
+
+        if args.out_customer_hex and not args.in_customer_hex:
+            raise ScriptError("--in-customer-hex is required when --out-customer-hex is used")
 
         # Validate secondary argument dependencies
         if args.secondary and args.secondary_address is None:
@@ -891,6 +907,7 @@ def cmd_handler(args: argparse.Namespace) -> None:
         secondary_periphconf_hex = IntelHex()
         mpcconf_hex = IntelHex()
         secondary_mpcconf_hex = IntelHex()
+        customer_hex = IntelHex()
 
         # Handle MPCCONF configuration
         if args.mpcconf:
@@ -944,6 +961,15 @@ def cmd_handler(args: argparse.Namespace) -> None:
 
             # Add periphconf data to periphconf hex object
             periphconf_hex.frombytes(periphconf_final, offset=args.periphconf_address)
+
+
+        if args.in_customer_hex:
+            if not Path(args.in_customer_hex).is_file():
+                raise ScriptError(
+                    f"args.in_customer_hex: The file {args.in_customer_hex} does not exist."
+                )
+            if args.out_customer_hex:
+                customer_hex.loadhex(args.in_customer_hex)
 
         # Handle secondary firmware configuration
         if args.secondary:
@@ -1067,6 +1093,10 @@ def cmd_handler(args: argparse.Namespace) -> None:
         if args.out_secondary_mpcconf_hex:
             secondary_mpcconf_hex.write_hex_file(args.out_secondary_mpcconf_hex)
             merged_hex.fromdict(secondary_mpcconf_hex.todict())
+
+        if args.out_customer_hex:
+            customer_hex.write_hex_file(args.out_customer_hex)
+            merged_hex.fromdict(customer_hex.todict())
 
         merged_hex.write_hex_file(args.out_merged_hex)
         uicr_hex.write_hex_file(args.out_uicr_hex)

--- a/soc/nordic/common/uicr/Kconfig.gen_uicr
+++ b/soc/nordic/common/uicr/Kconfig.gen_uicr
@@ -123,6 +123,17 @@ config GEN_UICR_GENERATE_MPCCONF
 	  When enabled, the UICR generator will populate the
 	  mpcconf_partition partition.
 
+config GEN_UICR_CUSTOMER
+	bool "UICR.CUSTOMER"
+	default n
+	help
+	  When enabled, the UICR generator will use a customer-provided
+	  hex file for the CUSTOMER field.
+
+config GEN_UICR_CUSTOMER_FILE_FULL_PATH
+	string "Full path to hex file for UICR customer data."
+	depends on GEN_UICR_CUSTOMER
+
 config GEN_UICR_WDTSTART
 	bool "UICR.WDTSTART"
 	help

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -96,6 +96,9 @@ set(periphconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/periphconf.hex)
 set(secondary_periphconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/secondary_periphconf.hex)
 set(mpcconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/mpcconf.hex)
 set(secondary_mpcconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/secondary_mpcconf.hex)
+set(in_customer_hex_file ${CONFIG_GEN_UICR_CUSTOMER_FILE_FULL_PATH})
+set(out_customer_hex_file ${APPLICATION_BINARY_DIR}/zephyr/customer.hex)
+
 
 # Get UICR absolute address from this image's devicetree
 dt_nodelabel(uicr_path NODELABEL "uicr" REQUIRED)
@@ -181,6 +184,16 @@ if(CONFIG_GEN_UICR_PERIPHCONF)
 
   list(APPEND periphconf_args --periphconf-address ${PERIPHCONF_ADDRESS})
   list(APPEND periphconf_args --periphconf-size ${PERIPHCONF_SIZE})
+endif()
+
+if(CONFIG_GEN_UICR_CUSTOMER)
+  if("${CONFIG_GEN_UICR_CUSTOMER_FILE_FULL_PATH}" STREQUAL "")
+    message(FATAL_ERROR
+      "Error CONFIG_GEN_UICR_CUSTOMER_FILE_FULL_PATH is an empty string."
+    )
+  endif()
+  list(APPEND customer_args --in-customer-hex ${in_customer_hex_file})
+  list(APPEND customer_args --out-customer-hex ${out_customer_hex_file})
 endif()
 
 if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF OR CONFIG_GEN_UICR_SECONDARY_GENERATE_PERIPHCONF OR
@@ -347,9 +360,11 @@ if(CONFIG_GEN_UICR_POLICY_MPCCONF_STAGE_INIT OR CONFIG_GEN_UICR_POLICY_MPCCONF_S
   list(APPEND policy_args --policy-mpcconf-stage ${CONFIG_GEN_UICR_POLICY_MPCCONF_STAGE_VALUE})
 endif()
 
+
 # Generate hex files (merged, uicr-only, periphconf-only, and secondary-periphconf-only)
 add_custom_command(
   OUTPUT ${merged_hex_file} ${uicr_hex_file} ${periphconf_hex_file} ${secondary_periphconf_hex_file}
+  ${out_customer_hex_file}
   COMMAND ${PYTHON_EXECUTABLE} ${IRONSIDE_SUPPORT_DIR}/se/tool/ironside/__main__.py
           gen-uicr
           --uicr-address ${UICR_ADDRESS}
@@ -368,7 +383,8 @@ add_custom_command(
           ${protectedmem_args}
           ${secondary_args}
           ${policy_args}
-  DEPENDS ${periphconf_elfs} ${secondary_periphconf_elfs}
+          ${customer_args}
+  DEPENDS ${periphconf_elfs} ${secondary_periphconf_elfs} ${in_customer_hex_file}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   COMMENT "Using gen_uicr.py to generate ${merged_hex_file}, ${uicr_hex_file}, ${periphconf_hex_file}, and ${secondary_periphconf_hex_file} from ${periphconf_elfs} ${secondary_periphconf_elfs}"
 )


### PR DESCRIPTION
This is a draft PR not intended to be merged.

Add CONFIG_GEN_UICR_CUSTOMER and CONFIG_GEN_UICR_CUSTOMER_FILE_FULL_PATH to let projects add a hex file with 
customer data that will be generated as part of the uicr.hex.