### PR TITLE
[nrf fromtree] scripts: west_commands: runners: nrf_common: use app c…

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -305,22 +305,15 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
 
     def _get_core(self):
         if self.family in ('nrf54h', 'nrf92'):
-            if (self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPUAPP') or
-                self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPUFLPR') or
-                self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPUPPR') or
-                self.build_conf.getboolean('CONFIG_SOC_NRF9280_CPUAPP')):
-                return 'Application'
             if (self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPURAD') or
                 self.build_conf.getboolean('CONFIG_SOC_NRF9280_CPURAD')):
                 return 'Network'
-            raise RuntimeError(f'Core not found for family: {self.family}')
+            return 'Application'
 
         if self.family in ('nrf53'):
-            if self.build_conf.getboolean('CONFIG_SOC_NRF5340_CPUAPP'):
-                return 'Application'
             if self.build_conf.getboolean('CONFIG_SOC_NRF5340_CPUNET'):
                 return 'Network'
-            raise RuntimeError(f'Core not found for family: {self.family}')
+            return 'Application'
 
         return None
 


### PR DESCRIPTION
…ore at default

Use Application core as default unless specified differently. This will make adding new product easier.


(cherry picked from commit db145a5af7b840ebf199d9e6c3f4925f17b4c0a3)