### PR TITLE
[nrf fromlist] dts: arm: nordic: correct reg in mailbox nodes

### DIFF
--- a/dts/arm/nordic/nrf54lm20_a_b_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54lm20_a_b_cpuapp.dtsi
@@ -45,7 +45,7 @@ nvic: &cpuapp_nvic {};
 &cpuflpr_vpr {
 	cpuapp_vevif_rx: mailbox@1 {
 		compatible = "nordic,nrf-vevif-event-rx";
-		reg = <0x0 0x1000>;
+		reg = <0x1 0x1000>;
 		status = "disabled";
 		interrupts = <76 NRF_DEFAULT_IRQ_PRIORITY>;
 		#mbox-cells = <1>;

--- a/dts/arm/nordic/nrf7120_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf7120_enga_cpuapp.dtsi
@@ -45,7 +45,7 @@ nvic: &cpuapp_nvic {};
 &cpuflpr_vpr {
 	cpuapp_vevif_rx: mailbox@1 {
 		compatible = "nordic,nrf-vevif-event-rx";
-		reg = <0x0 0x1000>;
+		reg = <0x1 0x1000>;
 		status = "disabled";
 		interrupts = <76 NRF_DEFAULT_IRQ_PRIORITY>;
 		#mbox-cells = <1>;


### PR DESCRIPTION
Unit address and first address now match.

Upstream PR #: 107485