### PR TITLE
Revert "[nrf noup] tests: ram_context_for_isr: Disable KMU by default"

### DIFF
--- a/tests/application_development/ram_context_for_isr/boards/nrf54l05dk_nrf54l05_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54l05dk_nrf54l05_cpuapp.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2025 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-CONFIG_CRACEN_LIB_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2025 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-CONFIG_CRACEN_LIB_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2025 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-CONFIG_CRACEN_LIB_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2025 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-CONFIG_CRACEN_LIB_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54lm20dk_nrf54lm20b_cpuapp.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2025 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-CONFIG_CRACEN_LIB_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2025 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-CONFIG_CRACEN_LIB_KMU=n

--- a/tests/application_development/ram_context_for_isr/boards/nrf7120pdk_nrf7120_cpuapp.conf
+++ b/tests/application_development/ram_context_for_isr/boards/nrf7120pdk_nrf7120_cpuapp.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2025 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-CONFIG_CRACEN_LIB_KMU=n


### PR DESCRIPTION
This PR reverts two [noup] commits that will be exchanged by local copy of sdk-zephyr test in sdk-nrf.