### PR TITLE
[nrf fromtree] samples: boards: nordic: coresight_stm: Minor fixes

### DIFF
--- a/samples/boards/nordic/coresight_stm/pytest/test_stm.py
+++ b/samples/boards/nordic/coresight_stm/pytest/test_stm.py
@@ -172,7 +172,7 @@ def nrfutil_dictionary_from_serial(
     decoded_file_name: str = "output.txt",
     collect_time: float = 60.0,
 ) -> None:
-    UART_PATH = dut.device_config.serial
+    UART_PATH = dut.device_config.serial_configs[0].port
     dut.close()
 
     logger.debug(f"Using serial: {UART_PATH}")

--- a/samples/boards/nordic/coresight_stm/pytest/test_stm.py
+++ b/samples/boards/nordic/coresight_stm/pytest/test_stm.py
@@ -302,7 +302,7 @@ def test_STM_decoded(dut: DeviceAdapter):
         log_2_arg=26.9,
         log_3_arg=27.5,
         log_str=68.3,
-        tracepoint=0.55,
+        tracepoint=0.9,
         tracepoint_d32=0.25,
         tolerance=0.5,
     )
@@ -313,8 +313,8 @@ def test_STM_decoded(dut: DeviceAdapter):
         log_2_arg=1.2,
         log_3_arg=1.2,
         log_str=3.0,
-        tracepoint=0.25,
-        tracepoint_d32=0.25,
+        tracepoint=0.5,
+        tracepoint_d32=0.5,
         tolerance=0.5,
     )
 

--- a/samples/boards/nordic/coresight_stm/pytest/test_stm.py
+++ b/samples/boards/nordic/coresight_stm/pytest/test_stm.py
@@ -454,8 +454,8 @@ def test_STM_dictionary_mode(dut: DeviceAdapter):
         log_2_arg=8.6,
         log_3_arg=17.4,
         log_str=45.2,
-        tracepoint=0.5,
-        tracepoint_d32=0.5,
+        tracepoint=1.5,
+        tracepoint_d32=1.5,
         tolerance=0.5,
     )
     flpr_constraints = STMLimits(

--- a/samples/boards/nordic/coresight_stm/pytest/test_stm.py
+++ b/samples/boards/nordic/coresight_stm/pytest/test_stm.py
@@ -203,7 +203,12 @@ def nrfutil_dictionary_from_serial(
     try:
         # run nrfutil trace in background non-blocking
         logger.info(f"Executing:\n{cmd}")
-        proc = subprocess.Popen(cmd.split(), stdout=subprocess.DEVNULL)
+        proc = subprocess.Popen(cmd.split(),
+                                stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                encoding='UTF-8',
+                                errors='replace')
     except OSError as exc:
         logger.error(f"Unable to start nrfutil trace:\n{cmd}\n{exc}")
     try:
@@ -212,6 +217,8 @@ def nrfutil_dictionary_from_serial(
         pass
     finally:
         _kill(proc)
+        outs, errs = proc.communicate()
+        logger.info(f"{outs=}\n{errs=}")
 
 
 def test_sample_STM_decoded(dut: DeviceAdapter):

--- a/samples/boards/nordic/coresight_stm/sample.yaml
+++ b/samples/boards/nordic/coresight_stm/sample.yaml
@@ -23,6 +23,9 @@ tests:
       - SB_CONFIG_APP_CPUFLPR_RUN=y
 
   sample.boards.nrf.coresight_stm.tpiu.dict:
+    harness: console
+    harness_config:
+      fixture: jlink_trace_pro
     required_snippets:
       - nordic-log-stm-tpiu-dict
     extra_args:
@@ -42,6 +45,11 @@ tests:
       - SB_CONFIG_APP_CPUFLPR_RUN=y
 
   sample.boards.nrf.coresight_stm.rtt:
+    harness: pytest
+    harness_config:
+      pytest_dut_scope: session
+      pytest_root:
+        - "pytest/test_stm.py::test_sample_STM_decoded"
     required_snippets:
       - nordic-log-stm
     extra_configs:


### PR DESCRIPTION
Limit execution of sample.boards.nrf.coresight_stm.tpiu.dict to test setups with jlink_trace_pro fixture as JLink Pro is required to use TPIU.

Define harness for sample.boards.nrf.coresight_stm.rtt. Otherwise, Twister is unable to derive test result.

Aling serial port use to the lates changes in the DeviceAdapter.


(cherry picked from commit fd434e2cb5e49a17b94e1c13e890c7d2b21d21ac)