### PR TITLE
[nrf noup] boards: nordic: Fix nrf92 flash offset

### DIFF
--- a/boards/nordic/nrf9280pdk/Kconfig.defconfig
+++ b/boards/nordic/nrf9280pdk/Kconfig.defconfig
@@ -14,13 +14,10 @@ endif # BOARD_NRF9280PDK_NRF9280_CPUPPR
 
 if BOARD_NRF9280PDK_NRF9280_CPUAPP
 
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
 config ROM_START_OFFSET
 	default 0x800 if BOOTLOADER_MCUBOOT
 
 config FLASH_LOAD_OFFSET
-	default $(sub_hex, $(dt_nodelabel_reg_addr_hex,cpuapp_boot_partition), \
-		$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))) if !USE_DT_CODE_PARTITION
+	default $(dt_nodelabel_reg_addr_hex,cpuapp_boot_partition) if !USE_DT_CODE_PARTITION
 
 endif # BOARD_NRF9280PDK_NRF9280_CPUAPP


### PR DESCRIPTION
Revert "[nrf fromtree] boards: nordic: fix flash_load_offset calculation" This reverts commit f9276d56a8b8f0b7199136790b7d386fcadf904b.

This was missed when removing the new partition address changes due to being merged later.

 Just a noup as it is aligned with a noup fix for all other platforms on NCS 3.3