### PR TITLE
Fix hal_nordic manifest history

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: af3848538da37360913bc68eeef40f32430b7c52
+      revision: 0424db2d8320cfe417af5675b5bfd2b9a8b43d23
       path: modules/hal/nordic
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 0424db2d8320cfe417af5675b5bfd2b9a8b43d23
+      revision: c8f0c2b6ecf66b0a4af24b5272d879c305868feb
       path: modules/hal/nordic
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 44fd3d44b15cb75f80a25b4679f91d2787e28664
+      revision: af3848538da37360913bc68eeef40f32430b7c52
       path: modules/hal/nordic
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 7142bc9c3c94f06e3b520890dde93d363c0e67bf
+      revision: 44fd3d44b15cb75f80a25b4679f91d2787e28664
       path: modules/hal/nordic
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: af3848538da37360913bc68eeef40f32430b7c52
+      revision: 7142bc9c3c94f06e3b520890dde93d363c0e67bf
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
The git history has become a mess.

I have described my analysis of what has happened in https://github.com/nrfconnect/sdk-zephyr/commit/337542359922281139ae6c5085e441eb84f5f4fe.

This PR attempts to fix the history and also update to the latest hal_nordic with some fromtree commits.