### PR TITLE
[nrf fromtree] drivers: pwm: pwm_nrfx: handle uninitialized period cycles

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -115,9 +115,10 @@ static bool pwm_period_check_and_set(const struct device *dev,
 
 	/* If any other channel is driven by the PWM peripheral, the period
 	 * that is currently set cannot be changed, as this would influence
-	 * the output for that channel.
+	 * the output for that channel, unless previous period was set to 0
+	 * for 100% duty cycle.
 	 */
-	if ((data->pwm_needed & ~BIT(channel)) != 0) {
+	if (((data->pwm_needed & ~BIT(channel)) != 0) && (data->period_cycles != 0)) {
 		LOG_ERR("Incompatible period.");
 		return false;
 	}

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -552,6 +552,7 @@
 				reg = <0xd2000 0x1000>;
 				interrupts = <210 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			pwm21: pwm@d3000 {
@@ -560,6 +561,7 @@
 				reg = <0xd3000 0x1000>;
 				interrupts = <211 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			pwm22: pwm@d4000 {
@@ -568,6 +570,7 @@
 				reg = <0xd4000 0x1000>;
 				interrupts = <212 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			adc: adc@d5000 {


### PR DESCRIPTION
If first PWM sequence is set to 100% glitch free duty cycle, period_cycles will remain uninitialized while all used channels will use PWM. If following sequences request non-100% duty cycle, period cycles will have to be changed. Improve error condition to allow changing period cycles for running PWM if these are equal to 0.