### PR TITLE
[nrf fromtree] net: fix maybe uninitialized warnings

### DIFF
--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -126,7 +126,7 @@ static int coap_server_process(int sock_fd)
 {
 	static uint8_t buf[CONFIG_COAP_SERVER_MESSAGE_SIZE];
 
-	struct net_sockaddr_storage client_addr;
+	struct net_sockaddr_storage client_addr = { 0 };
 	net_socklen_t client_addr_len = sizeof(client_addr);
 	struct coap_service *service = NULL;
 	struct coap_packet request;

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -976,7 +976,7 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
 {
 	struct tls_context *tls_ctx = ctx;
 	net_socklen_t addrlen = sizeof(struct net_sockaddr);
-	struct net_sockaddr_storage addr;
+	struct net_sockaddr_storage addr = { 0 };
 	int err;
 	ssize_t received;
 	uint8_t tmp_buf;
@@ -1032,7 +1032,7 @@ static int dtls_client_rx(void *ctx, unsigned char *buf, size_t len)
 {
 	struct tls_context *tls_ctx = ctx;
 	net_socklen_t addrlen = sizeof(struct net_sockaddr);
-	struct net_sockaddr_storage addr;
+	struct net_sockaddr_storage addr = { 0 };
 	ssize_t received;
 
 	received = zsock_recvfrom(tls_ctx->sock, buf, len,
@@ -1216,7 +1216,7 @@ static int dtls_server_switch_active_session_by_cid(struct tls_context *tls_ctx)
 static int dtls_server_switch_session_on_rx(struct tls_context *tls_ctx)
 {
 	net_socklen_t addrlen = sizeof(struct net_sockaddr);
-	struct net_sockaddr_storage addr;
+	struct net_sockaddr_storage addr = { 0 };
 	uint8_t tmp_buf;
 	int ret;
 


### PR DESCRIPTION
Fixes a few occurrences of "maybe uninitialized" variables that are flagged when -Wmaybe-uninitialized is enabled. Seen when running e.g. ./scripts/twister -p mps2/an385 -T tests/net/lib/coap_server/common in "--coverage" mode.

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>

(cherry picked from commit 2f558a5249cf8d9247ba76869c2487ec930b3144)

Fixes failing net tests: NCSDK-39259