### PR TITLE
Raw TX fixes and Revert race free sleep design

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -926,6 +926,11 @@ config NRF_WIFI_COEX_DISABLE_PRIORITY_WINDOW_FOR_SCAN
 	  Enable this configuration to disable priority window for scan
 	  in the case of coexistence with Short Range radio.
 
+config NRF_WIFI_DISPLAY_SCAN_ABORT_ON_BSS_LIMIT
+	bool "Abort scan when display BSS limit is reached"
+	help
+	  Enable this configuration to abort display scan when the BSS limit is reached.
+
 if NETWORKING
 config NRF_WIFI_ZERO_COPY_TX
 	bool "Zero copy Transmit path [EXPERIMENTAL]"

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -1385,9 +1385,6 @@ int nrf_wifi_stats_get(const struct device *dev, struct net_stats_wifi *zstats)
 	zstats->errors.rx = stats.host.total_rx_drop_pkts +
 			stats.fw.umac.interface_data_stats.rx_checksum_error_count;
 	zstats->overrun_count = stats.host.total_tx_drop_pkts + stats.host.total_rx_drop_pkts;
-#ifdef CONFIG_NRF70_RAW_DATA_TX
-	zstats->errors.tx += sys_dev_ctx->raw_pkt_stats.raw_pkt_send_failure;
-#endif /* CONFIG_NRF70_RAW_DATA_TX */
 
 	/* FMAC statistics */
 	status = nrf_wifi_sys_fmac_stats_get(rpu_ctx_zep->rpu_ctx,

--- a/include/zephyr/net/net_stats.h
+++ b/include/zephyr/net/net_stats.h
@@ -192,6 +192,23 @@ struct net_stats_udp {
 };
 
 /**
+ * @brief Raw packet socket statistics
+ */
+struct net_stats_raw {
+	/** Amount of received and sent raw packet data. */
+	struct net_stats_bytes bytes;
+
+	/** Number of dropped raw packets. */
+	net_stats_t drop;
+
+	/** Number of received raw packets. */
+	net_stats_t recv;
+
+	/** Number of sent raw packets. */
+	net_stats_t sent;
+};
+
+/**
  * @brief IPv6 neighbor discovery statistics
  */
 struct net_stats_ipv6_nd {
@@ -443,6 +460,11 @@ struct net_stats {
 #if defined(CONFIG_NET_STATISTICS_UDP)
 	/** UDP statistics */
 	struct net_stats_udp udp;
+#endif
+
+#if defined(CONFIG_NET_STATISTICS_RAW)
+	/** Raw packet socket statistics */
+	struct net_stats_raw raw;
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_IPV6_ND)
@@ -751,6 +773,7 @@ enum net_request_stats_cmd {
 	NET_REQUEST_STATS_CMD_GET_IPV4_PMTU,
 	NET_REQUEST_STATS_CMD_GET_ICMP,
 	NET_REQUEST_STATS_CMD_GET_UDP,
+	NET_REQUEST_STATS_CMD_GET_RAW,
 	NET_REQUEST_STATS_CMD_GET_TCP,
 	NET_REQUEST_STATS_CMD_GET_ETHERNET,
 	NET_REQUEST_STATS_CMD_GET_PPP,
@@ -864,6 +887,16 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_ICMP);
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_UDP);
 /** @endcond */
 #endif /* CONFIG_NET_STATISTICS_UDP */
+
+#if defined(CONFIG_NET_STATISTICS_RAW)
+/** Request raw packet socket statistics */
+#define NET_REQUEST_STATS_GET_RAW				\
+	(NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_RAW)
+
+/** @cond INTERNAL_HIDDEN */
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_RAW);
+/** @endcond */
+#endif /* CONFIG_NET_STATISTICS_RAW */
 
 #if defined(CONFIG_NET_STATISTICS_TCP)
 /** Request TCP statistics */
@@ -1118,6 +1151,50 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_RESET_WIFI);
 		&(iface)->stats.udp.chkerr)
 #else
 #define NET_STATS_PROMETHEUS_UDP(iface, dev_id, sfx)
+#endif
+
+/* Raw packet socket statistics */
+#if defined(CONFIG_NET_STATISTICS_RAW)
+#define NET_STATS_PROMETHEUS_RAW(iface, dev_id, sfx)			\
+	NET_STATS_PROMETHEUS_COUNTER_DEFINE(				\
+		"Raw packets sent",					\
+		NET_STATS_GET_INSTANCE(dev_id, sfx, raw_sent),		\
+		"packet_count",						\
+		NET_STATS_GET_COLLECTOR_NAME(dev_id, sfx),		\
+		NET_STATS_GET_VAR(dev_id, sfx, raw_sent),		\
+		&(iface)->stats.raw.sent);				\
+	NET_STATS_PROMETHEUS_COUNTER_DEFINE(				\
+		"Raw packets received",					\
+		NET_STATS_GET_INSTANCE(dev_id, sfx, raw_recv),		\
+		"packet_count",						\
+		NET_STATS_GET_COLLECTOR_NAME(dev_id, sfx),		\
+		NET_STATS_GET_VAR(dev_id, sfx, raw_recv),		\
+		&(iface)->stats.raw.recv);				\
+	NET_STATS_PROMETHEUS_COUNTER_DEFINE(				\
+		"Raw packets dropped",					\
+		NET_STATS_GET_INSTANCE(dev_id, sfx, raw_drop),		\
+		"packet_count",						\
+		NET_STATS_GET_COLLECTOR_NAME(dev_id, sfx),		\
+		NET_STATS_GET_VAR(dev_id, sfx, raw_drop),		\
+		&(iface)->stats.raw.drop);				\
+	NET_STATS_PROMETHEUS_COUNTER_DEFINE(				\
+		"Raw bytes sent",					\
+		NET_STATS_GET_INSTANCE(dev_id, sfx, raw_bytes_sent),	\
+		"byte_count",						\
+		NET_STATS_GET_COLLECTOR_NAME(dev_id, sfx),		\
+		NET_STATS_GET_VAR(dev_id, sfx, raw_bytes_sent),		\
+		&(iface)->stats.raw.bytes.sent);			\
+	NET_STATS_PROMETHEUS_COUNTER_DEFINE(				\
+		"Raw bytes received",					\
+		NET_STATS_GET_INSTANCE(dev_id, sfx, raw_bytes_recv),	\
+		"byte_count",						\
+		NET_STATS_GET_COLLECTOR_NAME(dev_id, sfx),		\
+		NET_STATS_GET_VAR(dev_id, sfx, raw_bytes_recv),		\
+		&(iface)->stats.raw.bytes.received)
+#else
+/** @cond INTERNAL_HIDDEN */
+#define NET_STATS_PROMETHEUS_RAW(iface, dev_id, sfx)
+/** @endcond */
 #endif
 
 /* TCP layer statistics */
@@ -1536,6 +1613,7 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_RESET_WIFI);
 	NET_STATS_PROMETHEUS_IPV4(iface, dev_id, sfx);			\
 	NET_STATS_PROMETHEUS_ICMP(iface, dev_id, sfx);			\
 	NET_STATS_PROMETHEUS_UDP(iface, dev_id, sfx);			\
+	NET_STATS_PROMETHEUS_RAW(iface, dev_id, sfx);			\
 	NET_STATS_PROMETHEUS_TCP(iface, dev_id, sfx);			\
 	NET_STATS_PROMETHEUS_IPV6_ND(iface, dev_id, sfx);		\
 	NET_STATS_PROMETHEUS_IPV6_PMTU(iface, dev_id, sfx);		\

--- a/subsys/net/ip/Kconfig.stats
+++ b/subsys/net/ip/Kconfig.stats
@@ -93,6 +93,13 @@ config NET_STATISTICS_TCP
 	help
 	  Keep track of TCP related statistics
 
+config NET_STATISTICS_RAW
+	bool "Raw packet socket statistics"
+	depends on NET_SOCKETS_PACKET
+	default y
+	help
+	  Keep track of raw packet socket related statistics
+
 config NET_STATISTICS_MLD
 	bool "Multicast Listener Discovery (MLD) statistics"
 	depends on NET_IPV6_MLD

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -624,12 +624,21 @@ static void conn_raw_socket_deliver(struct net_pkt *pkt, struct net_conn *conn,
 
 	raw_pkt = net_pkt_clone(pkt, K_MSEC(CONFIG_NET_CONN_PACKET_CLONE_TIMEOUT));
 	if (raw_pkt == NULL) {
+		if (!is_ip) {
+			net_stats_update_raw_drop(net_pkt_iface(pkt));
+		}
 		NET_WARN("pkt cloning failed, pkt %p not delivered", pkt);
 		goto out;
 	}
 
 	if (conn->cb(conn, raw_pkt, NULL, NULL, conn->user_data) == NET_DROP) {
+		if (!is_ip) {
+			net_stats_update_raw_drop(net_pkt_iface(pkt));
+		}
 		net_pkt_unref(raw_pkt);
+	} else if (!is_ip) {
+		net_stats_update_raw_recv(net_pkt_iface(pkt),
+					 net_pkt_get_len(raw_pkt));
 	}
 
 out:

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2817,6 +2817,7 @@ skip_alloc:
 
 		net_pkt_set_ll_proto_type(pkt, net_ntohs(ll_dst_addr->sll_protocol));
 
+		net_stats_update_raw_sent(net_pkt_iface(pkt), len);
 		net_if_try_queue_tx(net_pkt_iface(pkt), pkt, timeout);
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) && family == NET_AF_CAN &&
 		   net_context_get_proto(context) == NET_CAN_RAW) {

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -152,6 +152,16 @@ static inline void stats(struct net_if *iface)
 			 GET_STAT(iface, udp.chkerr));
 #endif
 
+#if defined(CONFIG_NET_STATISTICS_RAW)
+		NET_INFO("Raw recv       %u\tsent\t%u\tdrop\t%u",
+			 GET_STAT(iface, raw.recv),
+			 GET_STAT(iface, raw.sent),
+			 GET_STAT(iface, raw.drop));
+		NET_INFO("Raw bytes recv %llu\tsent\t%llu",
+			 GET_STAT(iface, raw.bytes.received),
+			 GET_STAT(iface, raw.bytes.sent));
+#endif
+
 #if defined(CONFIG_NET_STATISTICS_TCP)
 		NET_INFO("TCP bytes recv %llu\tsent\t%llu",
 			 GET_STAT(iface, tcp.bytes.received),
@@ -322,6 +332,12 @@ static int net_stats_get(uint64_t mgmt_request, struct net_if *iface,
 		src = GET_STAT_ADDR(iface, udp);
 		break;
 #endif
+#if defined(CONFIG_NET_STATISTICS_RAW)
+	case NET_REQUEST_STATS_CMD_GET_RAW:
+		len_chk = sizeof(struct net_stats_raw);
+		src = GET_STAT_ADDR(iface, raw);
+		break;
+#endif
 #if defined(CONFIG_NET_STATISTICS_TCP)
 	case NET_REQUEST_STATS_CMD_GET_TCP:
 		len_chk = sizeof(struct net_stats_tcp);
@@ -389,6 +405,11 @@ NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_GET_ICMP,
 
 #if defined(CONFIG_NET_STATISTICS_UDP)
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_GET_UDP,
+				  net_stats_get);
+#endif
+
+#if defined(CONFIG_NET_STATISTICS_RAW)
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_GET_RAW,
 				  net_stats_get);
 #endif
 

--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -276,6 +276,32 @@ static inline void net_stats_update_udp_chkerr(struct net_if *iface)
 #define net_stats_update_udp_chkerr(iface)
 #endif /* CONFIG_NET_STATISTICS_UDP */
 
+#if defined(CONFIG_NET_STATISTICS_RAW) && defined(CONFIG_NET_NATIVE)
+/* Raw packet socket stats */
+static inline void net_stats_update_raw_sent(struct net_if *iface,
+					     uint32_t bytes)
+{
+	UPDATE_STAT(iface, stats.raw.bytes.sent += bytes);
+	UPDATE_STAT(iface, stats.raw.sent++);
+}
+
+static inline void net_stats_update_raw_recv(struct net_if *iface,
+					     uint32_t bytes)
+{
+	UPDATE_STAT(iface, stats.raw.bytes.received += bytes);
+	UPDATE_STAT(iface, stats.raw.recv++);
+}
+
+static inline void net_stats_update_raw_drop(struct net_if *iface)
+{
+	UPDATE_STAT(iface, stats.raw.drop++);
+}
+#else
+#define net_stats_update_raw_sent(iface, bytes)
+#define net_stats_update_raw_recv(iface, bytes)
+#define net_stats_update_raw_drop(iface)
+#endif /* CONFIG_NET_STATISTICS_RAW */
+
 #if defined(CONFIG_NET_STATISTICS_TCP) && defined(CONFIG_NET_NATIVE_TCP)
 /* TCP stats */
 static inline void net_stats_update_tcp_sent(struct net_if *iface, uint32_t bytes)

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -585,6 +585,16 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 	   GET_STAT(iface, udp.chkerr));
 #endif
 
+#if defined(CONFIG_NET_STATISTICS_RAW)
+	PR("Raw recv       %u\tsent\t%u\tdrop\t%u\n",
+	   GET_STAT(iface, raw.recv),
+	   GET_STAT(iface, raw.sent),
+	   GET_STAT(iface, raw.drop));
+	PR("Raw bytes recv %llu\tsent\t%llu\n",
+	   GET_STAT(iface, raw.bytes.received),
+	   GET_STAT(iface, raw.bytes.sent));
+#endif
+
 #if defined(CONFIG_NET_STATISTICS_TCP) && defined(CONFIG_NET_NATIVE_TCP)
 	PR("TCP bytes recv %llu\tsent\t%llu\tresent\t%u\n",
 	   GET_STAT(iface, tcp.bytes.received),

--- a/west.yml
+++ b/west.yml
@@ -361,7 +361,7 @@ manifest:
       revision: 158b9710d6e10c57b2c623f8f4178f0bbc85c23f
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 1a4e59f4c6685877f6bff08bb1812bf9318da6d2
+      revision: 48a31a7149b019f7cc592a727c479361951f304b
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 5efe7974f9546582e99f5a842a816ea4b65f5227

--- a/west.yml
+++ b/west.yml
@@ -361,7 +361,7 @@ manifest:
       revision: 158b9710d6e10c57b2c623f8f4178f0bbc85c23f
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 48a31a7149b019f7cc592a727c479361951f304b
+      revision: 47bd5b4ebd357ba637be0f2b092e1c0d370eea2f
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 5efe7974f9546582e99f5a842a816ea4b65f5227


### PR DESCRIPTION
- Add support for net stats for raw modes (packet sockets), shell support to dump them
- Fixes for nRF70 raw modes (VIF handling, stats, error reporting etc)
- Revert Race free sleep design