### PR TITLE
[nrf fromtree] tests: drivers: flash: Verify 'supply-gpios' for SPI n…

### DIFF
--- a/tests/drivers/flash/common/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/flash/common/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -27,4 +27,5 @@
 &mx25uw63 {
 	status = "okay";
 	supply-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+	t-reset-recovery = <10000>;
 };

--- a/tests/drivers/flash/common/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/flash/common/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		test-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &mx25r64 {
 	status = "okay";
+	supply-gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+	t-reset-recovery = <10000>;
 };

--- a/tests/drivers/flash/common/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/flash/common/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		test-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &mx25r64 {
 	status = "okay";
+	supply-gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+	t-reset-recovery = <10000>;
 };


### PR DESCRIPTION
…or flash driver

Test SPI NOR flash driver ability to hande the 'supply-gpios' property.


(cherry picked from commit 08250dc6671f6035570de503451a5ce97b5baa8d)