### PR TITLE
[nrf fromtree] driver: gpio_nrfx: Remove config option for latch dete…

### DIFF
--- a/drivers/gpio/Kconfig.nrfx
+++ b/drivers/gpio/Kconfig.nrfx
@@ -17,7 +17,3 @@ config GPIO_NRFX_INTERRUPT
 	  The option can be used to disable the GPIO interrupt support to
 	  significantly reduce memory footprint in case of application that does
 	  not need GPIO interrupts.
-
-config GPIO_NRFX_HAS_LATCH_DETECT
-	bool
-	default y if !(SOC_NRF54H20 || SOC_SERIES_NRF92 || TRUSTED_EXECUTION_NONSECURE)

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -38,10 +38,6 @@
 #define GPIOTE_FLAG_FIXED_CHAN  BIT(1)
 #endif
 
-#if NRF_GPIO_HAS_DETECT_MODE && defined(CONFIG_GPIO_NRFX_HAS_LATCH_DETECT)
-#define GPIO_LATCH_DETECT_SUPPORT 1
-#endif
-
 struct gpio_nrfx_data {
 	/* gpio_driver_data needs to be first */
 	struct gpio_driver_data common;
@@ -55,7 +51,7 @@ struct gpio_nrfx_cfg {
 	nrfx_gpiote_t *gpiote;
 	uint32_t edge_sense;
 	uint8_t port_num;
-#if defined(GPIO_LATCH_DETECT_SUPPORT)
+#if NRF_GPIO_HAS_DETECT_MODE
 	bool latch_detect;
 #endif
 #if defined(GPIOTE_FEATURE_FLAG)
@@ -456,7 +452,7 @@ static int gpio_nrfx_pin_interrupt_configure(const struct device *port,
 		return 0;
 	}
 
-#if defined(GPIO_LATCH_DETECT_SUPPORT)
+#if NRF_GPIO_HAS_DETECT_MODE
 	nrf_gpio_port_detect_latch_set(cfg->port, cfg->latch_detect);
 #endif
 
@@ -707,7 +703,7 @@ static DEVICE_API(gpio, gpio_nrfx_drv_api_funcs) = {
 		.gpiote = GPIOTE_REF(id),						\
 		.edge_sense = DT_INST_PROP_OR(id, sense_edge_mask, 0),			\
 		.port_num = DT_INST_PROP(id, port),					\
-		IF_ENABLED(GPIO_LATCH_DETECT_SUPPORT,					\
+		IF_ENABLED(NRF_GPIO_HAS_DETECT_MODE,					\
 			(.latch_detect = DT_INST_PROP(id, latch_detect),))		\
 		IF_ENABLED(GPIOTE_FEATURE_FLAG,						\
 			(.flags =							\


### PR DESCRIPTION
…ction

Coming with nrfx 4.3, NRF_GPIO_HAS_DETECTMODE is now defned only when it is actually accessible.
Removed the hidden Kconfig option and used
nrfx symbol only.

Signed-off-by: Michał Stasiak <michal.stasiak@nordicsemi.no>

Upstream PR #: 108966