### PR TITLE
[nrf fromlist] west: runners: don't recover twice on nRF92

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -286,7 +286,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
 
 
     def recover_target(self):
-        if self.family in ('nrf53', 'nrf54h', 'nrf92'):
+        if self.family in ('nrf53', 'nrf54h'):
             self.logger.info(
                 'Recovering and erasing flash memory for both the network '
                 'and application cores.')
@@ -298,7 +298,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
         # recover operation unlocks the core and then flashes a small image that
         # keeps the debug access port open, recovering the network core last
         # would result in that small image being deleted from the app core.
-        if self.family in ('nrf53', 'nrf92'):
+        if self.family == 'nrf53':
             self.exec_op('recover', core='Network')
 
         self.exec_op('recover')


### PR DESCRIPTION
Remove unnecessary second recovery call from nRF92, as nRF92 is running Ironside SE, which already
performs a full erase of MRAM on recovery.

Upstream PR #: 108586
https://github.com/zephyrproject-rtos/zephyr/pull/108586