### PR TITLE
[nrf fromlist] tests: arch: common: interrupt: Share nrf92 and nrf54h…

### DIFF
--- a/tests/arch/common/gen_isr_table/src/main.c
+++ b/tests/arch/common/gen_isr_table/src/main.c
@@ -37,7 +37,8 @@ extern const uintptr_t _irq_vector_table[];
 #define ISR3_OFFSET	17
 #define ISR5_OFFSET	18
 #define TRIG_CHECK_SIZE	19
-#elif defined(CONFIG_SOC_SERIES_NRF54H) && defined(CONFIG_RISCV_CORE_NORDIC_VPR)
+#elif (defined(CONFIG_SOC_SERIES_NRF54H) || defined(CONFIG_SOC_SERIES_NRF92)) && \
+	defined(CONFIG_RISCV_CORE_NORDIC_VPR)
 #define ISR1_OFFSET	14
 #define ISR3_OFFSET	15
 #define ISR5_OFFSET	16
@@ -47,11 +48,6 @@ extern const uintptr_t _irq_vector_table[];
 #define ISR3_OFFSET	21
 #define ISR5_OFFSET	22
 #define TRIG_CHECK_SIZE	23
-#elif defined(CONFIG_SOC_NRF9280_CPUPPR)
-#define ISR1_OFFSET	14
-#define ISR3_OFFSET	15
-#define ISR5_OFFSET	16
-#define TRIG_CHECK_SIZE	17
 #else
 #error "Target not supported"
 #endif

--- a/tests/arch/common/interrupt/src/nested_irq.c
+++ b/tests/arch/common/interrupt/src/nested_irq.c
@@ -98,8 +98,8 @@
 static uint32_t irq_line_0;
 static uint32_t irq_line_1;
 
-static uint32_t isr0_result;
-static uint32_t isr1_result;
+static volatile uint32_t isr0_result;
+static volatile uint32_t isr1_result;
 
 void isr1(const void *param)
 {

--- a/tests/arch/common/interrupt/src/nested_irq.c
+++ b/tests/arch/common/interrupt/src/nested_irq.c
@@ -69,7 +69,8 @@
 
 #define IRQ0_PRIO	1
 #define IRQ1_PRIO	2
-#elif defined(CONFIG_SOC_SERIES_NRF54H) && defined(CONFIG_RISCV_CORE_NORDIC_VPR)
+#elif (defined(CONFIG_SOC_SERIES_NRF54H) || defined(CONFIG_SOC_SERIES_NRF92)) && \
+	defined(CONFIG_RISCV_CORE_NORDIC_VPR)
 #define IRQ0_LINE	14
 #define IRQ1_LINE	15
 
@@ -78,12 +79,6 @@
 #elif defined(CONFIG_SOC_SERIES_NRF71) && defined(CONFIG_RISCV_CORE_NORDIC_VPR)
 #define IRQ0_LINE	19
 #define IRQ1_LINE	20
-
-#define IRQ0_PRIO	1
-#define IRQ1_PRIO	2
-#elif defined(CONFIG_SOC_NRF9280_CPUPPR)
-#define IRQ0_LINE	14
-#define IRQ1_LINE	15
 
 #define IRQ0_PRIO	1
 #define IRQ1_PRIO	2

--- a/tests/arch/common/interrupt/src/test_shared_irq.h
+++ b/tests/arch/common/interrupt/src/test_shared_irq.h
@@ -29,7 +29,7 @@ static inline void name(const void *data)		\
 	test_vector[idx] = result_vector[idx];		\
 }							\
 
-static uint32_t test_vector[TEST_VECTOR_SIZE] = {
+static volatile uint32_t test_vector[TEST_VECTOR_SIZE] = {
 };
 
 static uint32_t result_vector[TEST_VECTOR_SIZE] = {

--- a/tests/kernel/sleep/src/usleep.c
+++ b/tests/kernel/sleep/src/usleep.c
@@ -42,8 +42,10 @@
  * loaded to its comparator.
  */
 #define MAXIMUM_SHORTEST_TICKS 2
-#elif defined(CONFIG_SOC_NRF54H20_CPUPPR) && (CONFIG_SYS_CLOCK_TICKS_PER_SEC > 16384)
-/* Similar for nRF54H20 cpuppr (RISC-V core), it has a slow CPU clock
+#elif defined(CONFIG_RISCV_CORE_NORDIC_VPR) && \
+	(DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency) < MHZ(32)) && \
+	(CONFIG_SYS_CLOCK_TICKS_PER_SEC > 16384)
+/* Similar for slow VPR cores (cpuppr, RISC-V core), it has a slow CPU clock
  * compared to other cores, causing the increased overhead.
  */
 #define MAXIMUM_SHORTEST_TICKS (IS_ENABLED(CONFIG_XIP) ? 8 : 4)


### PR DESCRIPTION
… configuration

nRF92 and nRF54H series share the same configuration for VPR core.

Signed-off-by: Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>

Upstream PR #: 109119