### PR TITLE
[nrf noup] boards: nordic: nrf7001: Include required headers

### DIFF
--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpuapp_nrf7001_ns.dts
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpuapp_nrf7001_ns.dts
@@ -7,6 +7,8 @@
 /dts-v1/;
 #include <arm/nordic/nrf5340_cpuapp_ns_qkaa.dtsi>
 #include "nrf5340_cpuapp_common.dtsi"
+#include "nordic/nrf5340_sram_partition.dtsi"
+#include "nordic/nrf5340_cpuapp_ns_partition.dtsi"
 
 / {
 	model = "Nordic NRF5340 DK NRF5340 Application";


### PR DESCRIPTION
The definitions of slot partitions and sram partition has been moved. Include corresponding headers.

Fixes NCSDK-39370.