### PR TITLE
[nrf fromlist] sysbuild: Fix merged hex output

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_merged_hex.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_merged_hex.cmake
@@ -15,57 +15,69 @@ function(create_merged_hex_files)
   # Parse each image to get the board target, normalise it and create a list of every image per
   # unique board target
   foreach(image ${sorted_flash_images})
-    set(board_target)
-    sysbuild_get(board_target IMAGE ${image} VAR CONFIG_BOARD_TARGET KCONFIG)
-    string(REPLACE "/" "_" board_target ${board_target})
-    string(REPLACE "." "_" board_target ${board_target})
-    string(REPLACE "@" "_" board_target ${board_target})
+    set(build_only)
+    set(build_dir)
 
-    if(NOT board_target IN_LIST board_targets)
-      list(APPEND board_targets ${board_target})
-      set(board_merge_images_${board_target})
+    get_target_property(build_only ${image} BUILD_ONLY)
+    get_target_property(build_dir ${image} _EP_BINARY_DIR)
+
+    if(DEFINED build_dir AND NOT build_only AND EXISTS ${build_dir}/zephyr/runners.yaml)
+      set(board_target)
+      sysbuild_get(board_target IMAGE ${image} VAR CONFIG_BOARD_TARGET KCONFIG)
+
+      if(NOT board_target)
+        continue()
+      endif()
+
+      string(REPLACE "/" "_" board_target ${board_target})
+      string(REPLACE "." "_" board_target ${board_target})
+      string(REPLACE "@" "_" board_target ${board_target})
+
+      if(NOT board_target IN_LIST board_targets)
+        list(APPEND board_targets ${board_target})
+        set(board_merge_images_${board_target})
+      endif()
+
+      list(APPEND board_merge_images_${board_target} ${image})
     endif()
-
-    list(APPEND board_merge_images_${board_target} ${image})
   endforeach()
 
   foreach(board_target ${board_targets})
     set(depends_list)
     set(input_list)
+    set(extra_dependencies)
 
     foreach(image ${board_merge_images_${board_target}})
       # Only process images that create hex files
       set(output_hex)
-      sysbuild_get(output_hex IMAGE ${image} VAR CONFIG_BUILD_OUTPUT_HEX KCONFIG)
+      set(build_dir)
+      set(application_image_dir)
 
-      if(output_hex)
-        # The order of files to use are (starting with highest priority):
-        # * <BYPRODUCT_KERNEL_SIGNED_CONFIRMED_HEX_NAME>
-        # * <BYPRODUCT_KERNEL_SIGNED_HEX_NAME>
-        # * <CONFIG_KERNEL_BIN_NAME>.hex
-        #
-        # This ensures that if the image has a signing script, that the signed image is used, the
-        # confirmed version should be used if MCUboot is used in directXIP mode so has the most
-        # priority. If there is no byproduct signed file, then the normal zephyr hex file is used
-        set(byproduct_signed_confirmed_hex)
-        set(byproduct_signed_hex)
-        set(kernel_name)
-        set(application_image_dir)
-        sysbuild_get(byproduct_signed_confirmed_hex IMAGE ${image} VAR BYPRODUCT_KERNEL_SIGNED_CONFIRMED_HEX_NAME CACHE)
-        sysbuild_get(byproduct_signed_hex IMAGE ${image} VAR BYPRODUCT_KERNEL_SIGNED_HEX_NAME CACHE)
-        sysbuild_get(kernel_name IMAGE ${image} VAR CONFIG_KERNEL_BIN_NAME KCONFIG)
-        sysbuild_get(application_image_dir IMAGE ${image} VAR APPLICATION_BINARY_DIR CACHE)
-        list(APPEND depends_list ${image}_extra_byproducts ${application_image_dir}/zephyr/.config)
+      get_target_property(build_dir ${image} _EP_BINARY_DIR)
+      yaml_load(FILE ${build_dir}/zephyr/runners.yaml NAME ${image}_runner_yaml)
+      yaml_get(output_hex NAME ${image}_runner_yaml KEY config hex_file)
+      sysbuild_get(application_image_dir IMAGE ${image} VAR APPLICATION_BINARY_DIR CACHE)
 
-        if(byproduct_signed_confirmed_hex)
-          list(APPEND input_list ${byproduct_signed_confirmed_hex})
-        elseif(byproduct_signed_hex)
-          list(APPEND input_list ${byproduct_signed_hex})
-        else()
-          list(APPEND input_list ${application_image_dir}/zephyr/${kernel_name}.hex)
-        endif()
+      if(TARGET ${image}_extra_byproducts)
+        list(APPEND depends_list ${image}_extra_byproducts)
+      endif()
+
+      if(application_image_dir AND EXISTS ${application_image_dir}/zephyr/.config)
+        list(APPEND depends_list ${application_image_dir}/zephyr/.config)
+      endif()
+
+      if(IS_ABSOLUTE ${output_hex})
+        list(APPEND input_list ${output_hex})
+      else()
+        list(APPEND input_list ${application_image_dir}/zephyr/${output_hex})
       endif()
     endforeach()
+
+    get_property(extra_dependencies GLOBAL PROPERTY sysbuild_merged_hex_dependencies_${board_target})
+
+    if(extra_dependencies)
+      list(APPEND depends_list ${extra_dependencies})
+    endif()
 
     # Use the mergehex python file to merge the hex file in flash-order with replace mode
     add_custom_command(


### PR DESCRIPTION
Fixes some issues with merged hex output, parses images to get the hex files that are flashed then uses that as the input for the merged hex output. Also allows sysbuild modules to add custom dependencies to the merged hex output if they generate the images

Upstream PR #: 109205

manifest-pr-skip