### PR TITLE
Nrfx 9388 switch to kconfig in wdt error cases

### DIFF
--- a/boards/nuvoton/numaker_pfm_m487/numaker_pfm_m487.dts
+++ b/boards/nuvoton/numaker_pfm_m487/numaker_pfm_m487.dts
@@ -19,6 +19,7 @@
 		led2 = &green_led;
 		sw0 = &sw2;
 		sw1 = &sw3;
+		watchdog0 = &wdt;
 	};
 
 	chosen {

--- a/boards/nuvoton/numaker_pfm_m487/numaker_pfm_m487.yaml
+++ b/boards/nuvoton/numaker_pfm_m487/numaker_pfm_m487.yaml
@@ -7,4 +7,6 @@ toolchain:
   - gnuarmemb
 ram: 160
 flash: 512
+supported:
+  - watchdog
 vendor: nuvoton

--- a/tests/drivers/watchdog/wdt_basic_api/boards/numaker_pfm_m487.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/numaker_pfm_m487.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -97,6 +97,9 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(nuvoton_numaker_wwdt)
 #define WDT_NODE DT_INST(0, nuvoton_numaker_wwdt)
 #define TIMEOUTS 1
+#elif DT_HAS_COMPAT_STATUS_OKAY(nuvoton_numaker_wdt)
+#define WDT_NODE DT_INST(0, nuvoton_numaker_wdt)
+#define TIMEOUTS 1
 #endif
 #if DT_HAS_COMPAT_STATUS_OKAY(raspberrypi_pico_watchdog)
 #define WDT_TEST_MAX_WINDOW 8000U

--- a/tests/drivers/watchdog/wdt_basic_reset_none/boards/numaker_pfm_m487.conf
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/boards/numaker_pfm_m487.conf
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# M48x WDT clocked by 10 kHz LIRC has coarse granularity.
+# tout=4 → 2^12 = 4096 ticks → 410 ms (rounded up).
+# SLEEP_TIME of 200 ms keeps feeds well within the period.
+# After last feed + 200 ms sleep, the WDT fires ~210 ms into the wait
+# window of 410 ms → comfortably in range.
+CONFIG_TEST_WDT_MAX_WINDOW_TIME=410
+CONFIG_TEST_WDT_SLEEP_TIME=200

--- a/tests/drivers/watchdog/wdt_basic_reset_none/boards/numaker_pfm_m487.overlay
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/boards/numaker_pfm_m487.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
@@ -7,6 +7,7 @@ tests:
       dt_compat_enabled("nxp,s32-swt")
       or dt_compat_enabled("renesas,ra-wdt")
       or dt_compat_enabled("silabs,gecko-wdog")
+      or dt_compat_enabled("nuvoton,numaker-wdt")
     integration_platforms:
       - s32z2xxdc2/s32z270/rtu0
     tags:

--- a/tests/drivers/watchdog/wdt_error_cases/Kconfig
+++ b/tests/drivers/watchdog/wdt_error_cases/Kconfig
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+config TEST_WDT_DISABLE_SUPPORTED
+	bool "Watchdog can be disabled after it was started"
+	default y
+	help
+	  This Kconfig is partially used to select test cases valid on a given platform.
+	  However, at some point, test suite requires WDT to be disabled after test.
+	  Therefore, this test suite currently can only be run on targets that
+	  support watchdog disable.
+
+config TEST_WDT_FLAG_RESET_NONE_SUPPORTED
+	bool "Watchdog flag WDT_FLAG_RESET_NONE is supported"
+	default y if SOC_FAMILY_SILABS_S2 || SOC_SERIES_M48X
+	help
+	  Set this Kconfig to 'y' if wdt_install_timeout() can be called with
+	  cfg.flags=WDT_FLAG_RESET_NONE.
+
+config TEST_WDT_FLAG_RESET_CPU_CORE_SUPPORTED
+	bool "Watchdog flag WDT_FLAG_RESET_CPU_CORE is supported"
+	default y if SOC_FAMILY_MICROCHIP_SAM_D5X_E5X || SOC_FAMILY_MICROCHIP_PIC32CX_SG
+	help
+	  Set this Kconfig to 'y' if wdt_install_timeout() can be called with
+	  cfg.flags=WDT_FLAG_RESET_CPU_CORE.
+
+config TEST_WDT_FLAG_RESET_SOC_SUPPORTED
+	bool "Watchdog flag WDT_FLAG_RESET_SOC is supported"
+	default y
+	help
+	  Set this Kconfig to 'y' if wdt_install_timeout() can be called with
+	  cfg.flags=WDT_FLAG_RESET_SOC.
+
+config TEST_MAX_INSTALLABLE_TIMEOUTS
+	int "Maximal number of timeouts that can be set for single Watchdog instance"
+	default 8 if NRFX_WDT
+	default 1
+	help
+	  Maximal number of timeouts that can be set with wdt_install_timeout()
+	  for the given Watchdog device.
+
+config TEST_WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED
+	bool "Watchdog supports only one timeout value for all timeouts"
+	default y
+	help
+	  Set this Kconfig to 'y' if all wdt_install_timeout() calls must set identical
+	  cfg.window value.
+
+config TEST_WDT_WINDOW_MIN_SUPPORTED
+	bool "Watchdog supports lower limit of watchdog feed timeout"
+	default y if SOC_FAMILY_SILABS_S2
+	help
+	  Set this Kconfig to 'y' if wdt_install_timeout() can be called with
+	  cfg.window.min value higher than 0.
+
+config TEST_WDT_WINDOW_MAX_ALLOWED
+	hex "Maximal value of Watchdog timeout"
+	default 0x07CFFFFF if NRFX_WDT
+	default 0x40001 if SOC_FAMILY_SILABS_S2
+	default 0x4000 if SOC_FAMILY_MICROCHIP_SAM_D5X_E5X || SOC_FAMILY_MICROCHIP_PIC32CX_SG
+	default 0xFFFFFFFF if SOC_IT51XXX
+	default 0x6667 if SOC_SERIES_M48X
+	default 0xFFFFFFF
+	help
+	  Maximal value of the Watchdog timeout passed in the
+	  wdt_install_timeout(dev, cfg.window.max) call.
+
+config TEST_WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED
+	bool "Watchdog supports option that pause timer when core enters sleep"
+	default y if NRFX_WDT || SOC_FAMILY_SILABS_S2
+	help
+	  Set this Kconfig to 'y' if wdt_setup() can be called with
+	  options=WDT_OPT_PAUSE_IN_SLEEP.
+
+config TEST_WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED
+	bool "Watchdog supports option that pause timer when core is halted by the debugger"
+	default y
+	help
+	  Set this Kconfig to 'y' if wdt_setup() can be called with
+	  options=WDT_OPT_PAUSE_HALTED_BY_DBG.
+
+config TEST_WDT_FEED_CAN_STALL
+	bool "Watchdog may report that wdt_feed() can stall the caller"
+	help
+	  Set this Kconfig to 'y' if wdt_feed() may return -EAGAIN when completing
+	  the feed operation would stall the caller, for example due to an in-progress
+	  watchdog operation such as a previous wdt_feed() call.
+
+source "Kconfig.zephyr"

--- a/tests/drivers/watchdog/wdt_error_cases/README.txt
+++ b/tests/drivers/watchdog/wdt_error_cases/README.txt
@@ -29,14 +29,14 @@ https://docs.zephyrproject.org/latest/hardware/peripherals/watchdog.html
 
 Follow these guidelines when enabling test execution on a new target.
 
-1. Although, code defines WDT_DISABLE_SUPPORTED but it was tested on a
-   target that supports disabling the watchdog.
-   Multiple tests call wdt_setup() which starts the watchdog.
-   Every test assumes that watchdog is disabled at startup.
+1. Although, code defines CONFIG_TEST_WDT_DISABLE_SUPPORTED but its use
+   in test cases is not fully implemented. In short, this test suite will FAIL
+   on a device that does NOT support disabling the Watchdog.
+   This is because multiple tests call wdt_setup() which starts the watchdog.
+   While, every test assumes that watchdog is disabled at startup.
    As a result, executing this test suite on a target that doesn't
    support wdt_disable() may require changes to the code.
-   When target supports wdt_disable() then extend WDT_TEST_FLAGS with:
-   #define WDT_TEST_FLAGS (... | WDT_DISABLE_SUPPORTED)
+   Currently CONFIG_TEST_WDT_DISABLE_SUPPORTED has default value 'y'.
 
 2. There are three watchdog flags that can be passed to wdt_install_timeout():
     - WDT_FLAG_RESET_NONE - when watchdog expires, it's callback is serviced but
@@ -45,35 +45,35 @@ Follow these guidelines when enabling test execution on a new target.
       other cores are not affected.
     - WDT_FLAG_RESET_SOC - when watchdog expires, target as "a whole" is reset.
    Support for these flags varies between vendors and products.
-   a) List all supported flags in
-      #define WDT_TEST_FLAGS (... | WDT_FLAG_RESET_NONE_SUPPORTED |
-                              WDT_FLAG_RESET_CPU_CORE_SUPPORTED |
-                              WDT_FLAG_RESET_SOC_SUPPORTED)
-   b) Set supported flag in
-      #define DEFAULT_FLAGS (WDT_FLAG_RESET_SOC)
+   a) Check if following Kconfigs have correct value for your target:
+      - CONFIG_TEST_WDT_FLAG_RESET_NONE_SUPPORTED,
+      - CONFIG_TEST_WDT_FLAG_RESET_CPU_CORE_SUPPORTED,
+      - CONFIG_TEST_WDT_FLAG_RESET_SOC_SUPPORTED.
+   b) Confirm that symbol DEFAULT_FLAGS (see main.c) gets correct value.
       This define will be used in wdt_install_timeout() "correct" test step.
 
-3. These tests assume that watchdog driver supports multiple timeouts. Set
-   #define MAX_INSTALLABLE_TIMEOUTS (8)
+3. Several tests check if HW supports multiple timeouts. Set value of
+   CONFIG_TEST_MAX_INSTALLABLE_TIMEOUTS
 
 4. When all watchdog timeouts must have exactly the same watchdog timeout value
-   then extend WDT_TEST_FLAGS with:
-   #define WDT_TEST_FLAGS (... | WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED)
+   then set CONFIG_TEST_WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED=y
 
-5. Set maximal allowed watchdog timeout value, f.e.:
-   #define WDT_WINDOW_MAX_ALLOWED (0xFFFFFFFFU)
-   Also, test assumes that minimal allowed watchdog timeout value must be zero.
+5. When HW supports setting minimal watchdog timeout value greater than 0, then set
+   CONFIG_TEST_WDT_WINDOW_MIN_SUPPORTED=y.
 
-6. There are two watchdog options that can be passed to wdt_setup():
+6. Set CONFIG_TEST_WDT_WINDOW_MAX_ALLOWED to maximal allowed watchdog timeout value.
+
+7. Test assumes that minimal allowed watchdog timeout value can be zero.
+   If not, add logic that changes value of DEFAULT_WINDOW_MIN symbol (see main.c).
+
+8. There are two watchdog options that can be passed to wdt_setup():
     - WDT_OPT_PAUSE_IN_SLEEP;
     - WDT_OPT_PAUSE_HALTED_BY_DBG.
    Support for these options varies between vendors and products.
-   a) List all supported options in
-      #define WDT_TEST_FLAGS (... | WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED |
-                              WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED)
-   b) Set supported option(s) in
-      #define DEFAULT_OPTIONS (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)
+   a) Check if following Kconfigs have correct value for your target:
+      - CONFIG_TEST_WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED,
+      - CONFIG_TEST_WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED.
+   b) Confirm that symbol DEFAULT_OPTIONS (see main.c) gets correct value.
       This define will be used in wdt_setup() "correct" test step.
 
-7. When wdt_feed() can stall, extend WDT_TEST_FLAGS with:
-   #define WDT_TEST_FLAGS (... | WDT_FEED_CAN_STALL)
+9. When wdt_feed() can stall, set CONFIG_TEST_WDT_FEED_CAN_STALL=y

--- a/tests/drivers/watchdog/wdt_error_cases/boards/numaker_pfm_m487.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/numaker_pfm_m487.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -19,6 +19,8 @@
 #define WDT_NODE DT_INST(0, nordic_nrf_wdt)
 #elif DT_HAS_COMPAT_STATUS_OKAY(zephyr_counter_watchdog)
 #define WDT_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_counter_watchdog)
+#elif DT_HAS_COMPAT_STATUS_OKAY(nuvoton_numaker_wdt)
+#define WDT_NODE DT_INST(0, nuvoton_numaker_wdt)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))
@@ -70,6 +72,14 @@
 #define MAX_INSTALLABLE_TIMEOUTS (1)
 #define WDT_WINDOW_MAX_ALLOWED   (0x40001U)
 #define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)
+#elif defined(CONFIG_SOC_SERIES_M48X)
+#define WDT_TEST_FLAGS                                                                             \
+	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_NONE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |    \
+	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED)
+#define DEFAULT_FLAGS            (WDT_FLAG_RESET_SOC)
+#define MAX_INSTALLABLE_TIMEOUTS (1)
+#define WDT_WINDOW_MAX_ALLOWED   (26215U)
+#define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_HALTED_BY_DBG)
 #elif defined(CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X) ||					   \
 	defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG)
 #define WDT_TEST_FLAGS                                                                             \

--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -29,86 +29,27 @@
 #define NOINIT_SECTION ".noinit.test_wdt"
 #endif
 
-/* Bit fields used to select tests to be run on the target */
-#define WDT_DISABLE_SUPPORTED                     BIT(0)
-#define WDT_FLAG_RESET_NONE_SUPPORTED             BIT(1)
-#define WDT_FLAG_RESET_CPU_CORE_SUPPORTED         BIT(2)
-#define WDT_FLAG_RESET_SOC_SUPPORTED              BIT(3)
-#define WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED BIT(4)
-#define WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED          BIT(5)
-#define WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED     BIT(6)
-#define WDT_FEED_CAN_STALL                        BIT(7)
-#define WDT_WINDOW_MIN_SUPPORTED                  BIT(8)
-#define WDT_OPT_PAUSE_IN_SLEEP_REQUIRES_PM        BIT(9)
-
 /* Common for all targets: */
 #define DEFAULT_WINDOW_MAX (500U)
 #define DEFAULT_WINDOW_MIN (0U)
 
-/* Align tests to the specific target: */
-#if defined(CONFIG_SOC_SERIES_NRF53) || defined(CONFIG_SOC_SERIES_NRF54L) || \
-	defined(CONFIG_SOC_SERIES_NRF71) || defined(CONFIG_SOC_NRF54H20) || \
-	defined(CONFIG_SOC_NRF9280)
-#define WDT_TEST_FLAGS                                                                             \
-	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
-	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED |            \
-	 WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED)
-#define DEFAULT_FLAGS            (WDT_FLAG_RESET_SOC)
-#define MAX_INSTALLABLE_TIMEOUTS (8)
-#define WDT_WINDOW_MAX_ALLOWED   (0x07CFFFFFU)
-#define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)
-#elif defined(CONFIG_SOC_FAMILY_SILABS_S2)
-#if defined(WDOG_CFG_EM1RUN)
-#define WDT_TEST_FLAG_SLEEP_REQUIRES_PM 0
-#else
-#define WDT_TEST_FLAG_SLEEP_REQUIRES_PM WDT_OPT_PAUSE_IN_SLEEP_REQUIRES_PM
-#endif
-#define WDT_TEST_FLAGS                                                                             \
-	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_NONE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |    \
-	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED |            \
-	 WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED | WDT_WINDOW_MIN_SUPPORTED |                        \
-	 WDT_TEST_FLAG_SLEEP_REQUIRES_PM)
+#if defined(CONFIG_TEST_WDT_FLAG_RESET_NONE_SUPPORTED)
 #define DEFAULT_FLAGS            (WDT_FLAG_RESET_NONE)
-#define MAX_INSTALLABLE_TIMEOUTS (1)
-#define WDT_WINDOW_MAX_ALLOWED   (0x40001U)
-#define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)
-#elif defined(CONFIG_SOC_SERIES_M48X)
-#define WDT_TEST_FLAGS                                                                             \
-	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_NONE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |    \
-	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED)
+#elif defined(CONFIG_TEST_WDT_FLAG_RESET_SOC_SUPPORTED)
 #define DEFAULT_FLAGS            (WDT_FLAG_RESET_SOC)
-#define MAX_INSTALLABLE_TIMEOUTS (1)
-#define WDT_WINDOW_MAX_ALLOWED   (26215U)
-#define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_HALTED_BY_DBG)
-#elif defined(CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X) ||					   \
-	defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG)
-#define WDT_TEST_FLAGS                                                                             \
-	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
-	 WDT_FLAG_RESET_CPU_CORE_SUPPORTED | WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED |           \
-	 WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED)
-#define DEFAULT_FLAGS            (WDT_FLAG_RESET_SOC)
-#define MAX_INSTALLABLE_TIMEOUTS (1)
-#define WDT_WINDOW_MAX_ALLOWED   (0x4000)
-#define DEFAULT_OPTIONS          (0)
-#elif defined(CONFIG_SOC_IT51XXX)
-#define WDT_TEST_FLAGS                                                                             \
-	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
-	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED)
-#define DEFAULT_FLAGS            WDT_FLAG_RESET_SOC
-#define MAX_INSTALLABLE_TIMEOUTS (1)
-#define WDT_WINDOW_MAX_ALLOWED   0xFFFFFFFFU
+#elif defined(CONFIG_TEST_WDT_FLAG_RESET_CPU_CORE_SUPPORTED)
+#define DEFAULT_FLAGS            (WDT_FLAG_RESET_CPU_CORE)
+#else
+#error "DEFAULT_FLAGS is not set"
+#endif
+
+#if defined(CONFIG_TEST_WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED)
+#define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_IN_SLEEP)
+#elif defined(CONFIG_TEST_WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED)
 #define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_HALTED_BY_DBG)
 #else
-/* By default run most of the error checks.
- * See Readme.txt on how to align test scope for the specific target.
- */
-#define WDT_TEST_FLAGS                                                                             \
-	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
-	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED)
-#define DEFAULT_FLAGS            (WDT_FLAG_RESET_SOC)
-#define MAX_INSTALLABLE_TIMEOUTS (8)
-#define WDT_WINDOW_MAX_ALLOWED   (0xFFFFFFFFU)
-#define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_IN_SLEEP)
+/* It is allowed for HW to NOT support pausing WDT timer in sleep, nor in debugg session. */
+#define DEFAULT_OPTIONS          (0)
 #endif
 
 static const struct device *const wdt = DEVICE_DT_GET(WDT_NODE);
@@ -165,10 +106,8 @@ ZTEST(wdt_coverage, test_01_wdt_disable_before_wdt_setup)
 {
 	int ret;
 
-	if (!(WDT_TEST_FLAGS & WDT_DISABLE_SUPPORTED)) {
-		/* Skip this test because wdt_disable() is NOT supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because wdt_disable() is NOT supported. */
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_WDT_DISABLE_SUPPORTED);
 
 	/* Call wdt_disable before enabling wdt */
 	ret = wdt_disable(wdt);
@@ -229,10 +168,8 @@ ZTEST(wdt_coverage, test_04a_wdt_install_timeout_WDT_FLAG_RESET_NONE_not_support
 {
 	int ret;
 
-	if (WDT_TEST_FLAGS & WDT_FLAG_RESET_NONE_SUPPORTED) {
-		/* Skip this test because WDT_FLAG_RESET_NONE is supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because WDT_FLAG_RESET_NONE is supported. */
+	Z_TEST_SKIP_IFDEF(CONFIG_TEST_WDT_FLAG_RESET_NONE_SUPPORTED);
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = WDT_FLAG_RESET_NONE;
@@ -257,10 +194,8 @@ ZTEST(wdt_coverage, test_04b_wdt_install_timeout_WDT_FLAG_RESET_CPU_CORE_not_sup
 {
 	int ret;
 
-	if (WDT_TEST_FLAGS & WDT_FLAG_RESET_CPU_CORE_SUPPORTED) {
-		/* Skip this test because WDT_FLAG_RESET_CPU_CORE is supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because WDT_FLAG_RESET_CPU_CORE is supported. */
+	Z_TEST_SKIP_IFDEF(CONFIG_TEST_WDT_FLAG_RESET_CPU_CORE_SUPPORTED);
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = WDT_FLAG_RESET_CPU_CORE;
@@ -285,10 +220,8 @@ ZTEST(wdt_coverage, test_04c_wdt_install_timeout_WDT_FLAG_RESET_SOC_not_supporte
 {
 	int ret;
 
-	if (WDT_TEST_FLAGS & WDT_FLAG_RESET_SOC_SUPPORTED) {
-		/* Skip this test because WDT_FLAG_RESET_SOC is supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because WDT_FLAG_RESET_SOC is supported. */
+	Z_TEST_SKIP_IFDEF(CONFIG_TEST_WDT_FLAG_RESET_SOC_SUPPORTED);
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = WDT_FLAG_RESET_SOC;
@@ -319,17 +252,17 @@ ZTEST(wdt_coverage, test_04w_wdt_install_timeout_with_invalid_window)
 	m_cfg_wdt0.window.max = DEFAULT_WINDOW_MAX;
 	m_cfg_wdt0.window.min = DEFAULT_WINDOW_MIN;
 
+#if !defined(CONFIG_TEST_WDT_WINDOW_MIN_SUPPORTED)
 	/* ----------------- window.min
 	 * Check that window.min can't be different than 0
 	 */
-	if (!(WDT_TEST_FLAGS & WDT_WINDOW_MIN_SUPPORTED)) {
-		m_cfg_wdt0.window.min = 1U;
-		ret = wdt_install_timeout(wdt, &m_cfg_wdt0);
-		zassert_true(ret == -EINVAL,
-			"Calling wdt_install_timeout with window.min = 1 should return -EINVAL (-22), "
-			"got unexpected value of %d",
-			ret);
-	}
+	m_cfg_wdt0.window.min = 1U;
+	ret = wdt_install_timeout(wdt, &m_cfg_wdt0);
+	zassert_true(ret == -EINVAL,
+		"Calling wdt_install_timeout with window.min = 1 should return -EINVAL (-22), "
+		"got unexpected value of %d",
+		ret);
+#endif
 
 	/* Set default window.min */
 	m_cfg_wdt0.window.min = DEFAULT_WINDOW_MIN;
@@ -345,12 +278,12 @@ ZTEST(wdt_coverage, test_04w_wdt_install_timeout_with_invalid_window)
 		     ret);
 
 	/* Check that window.max can't exceed maximum allowed value */
-	m_cfg_wdt0.window.max = WDT_WINDOW_MAX_ALLOWED + 1;
+	m_cfg_wdt0.window.max = CONFIG_TEST_WDT_WINDOW_MAX_ALLOWED + 1;
 	ret = wdt_install_timeout(wdt, &m_cfg_wdt0);
 	zassert_true(ret == -EINVAL,
 		     "Calling wdt_install_timeout with window.max = %d should return -EINVAL "
 		     "(-22), got unexpected value of %d",
-		     WDT_WINDOW_MAX_ALLOWED + 1, ret);
+		     CONFIG_TEST_WDT_WINDOW_MAX_ALLOWED + 1, ret);
 }
 
 /**
@@ -366,12 +299,10 @@ ZTEST(wdt_coverage, test_04wm_wdt_install_timeout_with_multiple_timeout_values)
 {
 	int ret;
 
-	if (!(WDT_TEST_FLAGS & WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED)) {
-		/* Skip this test because timeouts with different values are supported */
-		ztest_test_skip();
-	}
+	/* Skip this test because timeouts with different values are supported */
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED);
 
-	if (MAX_INSTALLABLE_TIMEOUTS < 2) {
+	if (CONFIG_TEST_MAX_INSTALLABLE_TIMEOUTS < 2) {
 		/* Skip this test because two timeouts aren't supported */
 		ztest_test_skip();
 	}
@@ -386,7 +317,7 @@ ZTEST(wdt_coverage, test_04wm_wdt_install_timeout_with_multiple_timeout_values)
 	TC_PRINT("Configured WDT channel %d\n", ret);
 
 	/* Call wdt_install_timeout again with different window */
-	m_cfg_wdt0.window.max = WDT_WINDOW_MAX_ALLOWED >> 1;
+	m_cfg_wdt0.window.max = CONFIG_TEST_WDT_WINDOW_MAX_ALLOWED >> 1;
 	ret = wdt_install_timeout(wdt, &m_cfg_wdt0);
 	zassert_true(ret == -EINVAL,
 		     "wdt_install_timeout should return -EINVAL (-22), got unexpected value of %d",
@@ -438,10 +369,8 @@ ZTEST(wdt_coverage, test_06a_wdt_setup_WDT_OPT_PAUSE_IN_SLEEP_not_supported)
 {
 	int ret;
 
-	if (WDT_TEST_FLAGS & WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED) {
-		/* Skip this test because WDT_OPT_PAUSE_IN_SLEEP is supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because WDT_OPT_PAUSE_IN_SLEEP is supported. */
+	Z_TEST_SKIP_IFDEF(CONFIG_TEST_WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED);
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = DEFAULT_FLAGS;
@@ -476,15 +405,15 @@ ZTEST(wdt_coverage, test_06b_wdt_setup_WDT_OPT_PAUSE_IN_SLEEP_functional)
 {
 	int ret;
 
-	if (!(WDT_TEST_FLAGS & WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED)) {
-		/* Skip this test because WDT_OPT_PAUSE_IN_SLEEP can NOT be used. */
-		ztest_test_skip();
-	}
+	/* Skip this test because WDT_OPT_PAUSE_IN_SLEEP can NOT be used. */
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED);
 
-	if ((WDT_TEST_FLAGS & WDT_OPT_PAUSE_IN_SLEEP_REQUIRES_PM) && !IS_ENABLED(CONFIG_PM)) {
+#if defined(CONFIG_SOC_FAMILY_SILABS_S2) && !defined(WDOG_CFG_EM1RUN)
+	if (!IS_ENABLED(CONFIG_PM)) {
 		/* Skip this test because WDT_OPT_PAUSE_IN_SLEEP can't be tested without PM. */
 		ztest_test_skip();
 	}
+#endif
 
 	/* When test fails, watchdog sets m_test_06b_value to TEST_06B_TAG in WDT callback
 	 * wdt_test_06b_cb. Then, target is reset. Check value of m_test_06b_value to prevent reset
@@ -532,10 +461,8 @@ ZTEST(wdt_coverage, test_06c_wdt_setup_WDT_OPT_PAUSE_HALTED_BY_DBG_not_supported
 {
 	int ret;
 
-	if (WDT_TEST_FLAGS & WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED) {
-		/* Skip this test because WDT_OPT_PAUSE_HALTED_BY_DBG is supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because WDT_OPT_PAUSE_HALTED_BY_DBG is supported. */
+	Z_TEST_SKIP_IFDEF(CONFIG_TEST_WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED);
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = DEFAULT_FLAGS;
@@ -627,15 +554,13 @@ ZTEST(wdt_coverage, test_08a_wdt_disable_not_supported)
 {
 	int ret;
 
-	if (WDT_TEST_FLAGS & WDT_DISABLE_SUPPORTED) {
-		/* Skip this test because wdt_disable() is supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because wdt_disable() is supported. */
+	Z_TEST_SKIP_IFDEF(CONFIG_TEST_WDT_DISABLE_SUPPORTED);
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = DEFAULT_FLAGS;
 	/* Assumption - test suite execution finishes before WDT timeout will fire */
-	m_cfg_wdt0.window.max = WDT_WINDOW_MAX_ALLOWED;
+	m_cfg_wdt0.window.max = CONFIG_TEST_WDT_WINDOW_MAX_ALLOWED;
 	m_cfg_wdt0.window.min = DEFAULT_WINDOW_MIN;
 
 	ret = wdt_install_timeout(wdt, &m_cfg_wdt0);
@@ -664,10 +589,8 @@ ZTEST(wdt_coverage, test_08b_wdt_disable_check_not_firing)
 {
 	int ret;
 
-	if (!(WDT_TEST_FLAGS & WDT_DISABLE_SUPPORTED)) {
-		/* Skip this test because wdt_disable() is NOT supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because wdt_disable() is NOT supported. */
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_WDT_DISABLE_SUPPORTED);
 
 	/* When test fails, watchdog sets m_test_08b_value to TEST_08B_TAG in WDT callback
 	 * wdt_test_08b_cb. Then, target is reset. Check value of m_test_08b_value to prevent reset
@@ -724,10 +647,8 @@ ZTEST(wdt_coverage, test_08c_wdt_disable_check_timeouts_reusable)
 {
 	int ret, id1, id2;
 
-	if (!(WDT_TEST_FLAGS & WDT_DISABLE_SUPPORTED)) {
-		/* Skip this test because wdt_disable() is NOT supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because wdt_disable() is NOT supported. */
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_WDT_DISABLE_SUPPORTED);
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = DEFAULT_FLAGS;
@@ -766,10 +687,8 @@ ZTEST(wdt_coverage, test_08d_wdt_disable_check_timeouts_uninstalled)
 {
 	int ret, id_A, id_B, i;
 
-	if (!(WDT_TEST_FLAGS & WDT_DISABLE_SUPPORTED)) {
-		/* Skip this test because wdt_disable() is NOT supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because wdt_disable() is NOT supported. */
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_WDT_DISABLE_SUPPORTED);
 
 	/* m_test_08d_A_value is set to TEST_08D_A_TAG in callback wdt_test_08d_A_cb */
 	if (m_test_08d_A_value == TEST_08D_A_TAG) {
@@ -847,10 +766,8 @@ ZTEST(wdt_coverage, test_08e_wdt_setup_immediately_after_wdt_disable)
 {
 	int ret;
 
-	if (!(WDT_TEST_FLAGS & WDT_DISABLE_SUPPORTED)) {
-		/* Skip this test because wdt_disable() is NOT supported. */
-		ztest_test_skip();
-	}
+	/* Skip this test because wdt_disable() is NOT supported. */
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_WDT_DISABLE_SUPPORTED);
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = DEFAULT_FLAGS;
@@ -951,10 +868,10 @@ ZTEST(wdt_coverage, test_09b_wdt_feed_invalid_channel)
 		     "wdt_feed(-1) shall return -EINVAL (-22), got unexpected value of %d", ret);
 
 	/* Call wdt_feed() on invalid channel (no such channel) */
-	ret = wdt_feed(wdt, MAX_INSTALLABLE_TIMEOUTS);
+	ret = wdt_feed(wdt, CONFIG_TEST_MAX_INSTALLABLE_TIMEOUTS);
 	zassert_true(ret == -EINVAL,
 		     "wdt_feed(%d) shall return -EINVAL (-22), got unexpected value of %d",
-		     MAX_INSTALLABLE_TIMEOUTS, ret);
+		     CONFIG_TEST_MAX_INSTALLABLE_TIMEOUTS, ret);
 
 	/* Assumption: wdt_disable() is called after each test */
 }
@@ -971,10 +888,8 @@ ZTEST(wdt_coverage, test_09c_wdt_feed_stall)
 {
 	int ret, ch_id, i;
 
-	if (!(WDT_TEST_FLAGS & WDT_FEED_CAN_STALL)) {
-		/* Skip this test because wdt_feed() can NOT stall. */
-		ztest_test_skip();
-	}
+	/* Skip this test because wdt_feed() can NOT stall. */
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_WDT_FEED_CAN_STALL);
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = DEFAULT_FLAGS;
@@ -1018,10 +933,12 @@ ZTEST(wdt_coverage, test_10_wdt_install_timeout_max_number_of_timeouts)
 	m_cfg_wdt0.window.max = DEFAULT_WINDOW_MAX;
 	m_cfg_wdt0.window.min = DEFAULT_WINDOW_MIN;
 
-	for (i = 0; i < MAX_INSTALLABLE_TIMEOUTS; i++) {
+	for (i = 0; i < CONFIG_TEST_MAX_INSTALLABLE_TIMEOUTS; i++) {
 		ret = wdt_install_timeout(wdt, &m_cfg_wdt0);
-		/* Assumption - timeouts are counted from 0 to (MAX_INSTALLABLE_TIMEOUTS - 1) */
-		zassert_true(ret < MAX_INSTALLABLE_TIMEOUTS,
+		/* Assumption - timeouts are counted from 0 to
+		 * (CONFIG_TEST_MAX_INSTALLABLE_TIMEOUTS - 1)
+		 */
+		zassert_true(ret < CONFIG_TEST_MAX_INSTALLABLE_TIMEOUTS,
 			     "Watchdog install error, got unexpected value of %d", ret);
 		TC_PRINT("Configured WDT channel %d\n", ret);
 	}
@@ -1052,10 +969,10 @@ static void before_test(void *not_used)
 
 static void cleanup_after_test(void *f)
 {
-	if (WDT_TEST_FLAGS & WDT_DISABLE_SUPPORTED) {
+#if defined(CONFIG_TEST_WDT_DISABLE_SUPPORTED)
 		/* Disable watchdog so it doesn't break other tests */
 		wdt_disable(wdt);
-	}
+#endif
 }
 
 ZTEST_SUITE(wdt_coverage, NULL, suite_setup, before_test, cleanup_after_test, NULL);

--- a/tests/drivers/watchdog/wdt_error_cases/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_error_cases/testcase.yaml
@@ -24,6 +24,7 @@ tests:
       - raytac_an54lq_db_15/nrf54l15/cpuapp
       - sam_e54_xpro
       - pic32cx_sg41_cult
+      - numaker_pfm_m487
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp

--- a/tests/drivers/watchdog/wdt_variables/boards/numaker_pfm_m487.overlay
+++ b/tests/drivers/watchdog/wdt_variables/boards/numaker_pfm_m487.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_variables/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_variables/testcase.yaml
@@ -21,6 +21,7 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - numaker_pfm_m487
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf7120dk/nrf7120/cpuapp


### PR DESCRIPTION
Change test code to ease test configuration for a new platform.

Instead of defining test configuration in main.c define Kconfigs.
Kconfig value can be set much easier.