### PR TITLE
net: l2: wifi: Add Kconfig option to control automatic DHCPv4 start

### DIFF
--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -165,6 +165,18 @@ endif # WIFI_SHELL_RUNTIME_CERTIFICATES
 
 endif # WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 
+config WIFI_STA_AUTO_DHCPV4
+	bool "Automatically start DHCPv4 after STA connects"
+	depends on NET_DHCPV4
+	default y
+	help
+	  When enabled, the DHCPv4 client is automatically started
+	  by the Wi-Fi driver or supplicant after the STA connection
+	  is established.
+	  If this option is disabled, the application layer is
+	  responsible for either manually starting the DHCPv4 client
+	  or configuring a static IPv4 address.
+
 config WIFI_MGMT_BSS_MAX_IDLE_TIME
 	int "BSS max idle timeout in seconds"
 	range 0 64000


### PR DESCRIPTION
Add a new Kconfig option WIFI_STA_AUTO_DHCPV4 to allow applications to control whether DHCPv4 client should be automatically started by the Wi-Fi driver or supplicant after STA connection is established. This addresses the use case where applications need to switch between static IP addressing and DHCP, or prefer to manually control when the DHCP client starts.
When CONFIG_WIFI_STA_AUTO_DHCPV4=n, the application layer becomes responsible for either manually starting the DHCPv4 client or configuring a static IPv4 address after Wi-Fi connection is established. The option defaults to 'y' to maintain backward compatibility with existing behavior.

manifest-pr-skip