### PR TITLE
[Backport ncs-v3.4-branch] [nrf fromtree] posix: Decouple POSIX_MULTI_PROCESS Kconfig from POSIX_SIGNALS

### DIFF
--- a/lib/posix/options/Kconfig.signal
+++ b/lib/posix/options/Kconfig.signal
@@ -22,7 +22,6 @@ endif # POSIX_REALTIME_SIGNALS
 
 config POSIX_SIGNALS
 	bool "POSIX signals"
-	select POSIX_MULTI_PROCESS
 	help
 	  Enable support for POSIX signals.
 


### PR DESCRIPTION
Backport e321c108d04e2f192b55a90de850e182ec5cb553 from #4119.