### PR TITLE
[Backport ncs-v3.4-branch] [nrf fromlist] drivers: flash_mspi_nor: Add support for DPD mode

### DIFF
--- a/drivers/flash/Kconfig.mspi
+++ b/drivers/flash/Kconfig.mspi
@@ -79,6 +79,17 @@ config FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE
 	  Other options include the 32K-byte erase size (32768), the sector
 	  size (4096), or any non-zero multiple of the sector size.
 
+config FLASH_MSPI_NOR_ACTIVE_DWELL_MS
+	int "Dwell period (ms) after last use to stay in active mode"
+	depends on PM_DEVICE_RUNTIME
+	default 10
+	help
+	  Flash accesses commonly occur in bursts, where entering and exiting DPD
+	  mode between each access adds significantly to the total operation time.
+	  This option controls how long to remain in active mode after each API
+	  call, eliminating the active->idle->active transition sequence if another
+	  transaction occurs before the dwell period expires.
+
 config FLASH_MSPI_NOR_DMA_DATA_XFER
 	bool "Use DMA for Flash MSPI NOR data transfers"
 	depends on MSPI_DMA

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -16,6 +16,12 @@
 
 LOG_MODULE_REGISTER(flash_mspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
+#if defined(CONFIG_FLASH_MSPI_NOR_ACTIVE_DWELL_MS)
+#define ACTIVE_DWELL_MS CONFIG_FLASH_MSPI_NOR_ACTIVE_DWELL_MS
+#else
+#define ACTIVE_DWELL_MS 0
+#endif
+
 #define XIP_DEV_CFG_MASK (MSPI_DEVICE_CONFIG_CMD_LEN | \
 			  MSPI_DEVICE_CONFIG_ADDR_LEN | \
 			  MSPI_DEVICE_CONFIG_READ_CMD | \
@@ -241,7 +247,19 @@ static int cmd_wrsr(const struct device *dev, uint8_t op_code,
 	return 0;
 }
 
-static int acquire(const struct device *dev)
+static void release_power(const struct device *dev)
+{
+	if (ACTIVE_DWELL_MS != 0 &&
+	    IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME_ASYNC)) {
+		k_timeout_t delay = K_MSEC(ACTIVE_DWELL_MS);
+
+		(void)pm_device_runtime_put_async(dev, delay);
+	} else {
+		(void)pm_device_runtime_put(dev);
+	}
+}
+
+static int _acquire(const struct device *dev)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
 	struct flash_mspi_nor_data *dev_data = dev->data;
@@ -253,7 +271,7 @@ static int acquire(const struct device *dev)
 
 	rc = pm_device_runtime_get(dev_config->bus);
 	if (rc < 0) {
-		LOG_ERR("pm_device_runtime_get() failed: %d", rc);
+		LOG_ERR("pm_device_runtime_get() for bus failed: %d", rc);
 	} else {
 		enum mspi_dev_cfg_mask mask;
 
@@ -288,7 +306,25 @@ static int acquire(const struct device *dev)
 	return rc;
 }
 
-static void release(const struct device *dev)
+static int acquire(const struct device *dev)
+{
+	int rc;
+
+	rc = pm_device_runtime_get(dev);
+	if (rc < 0) {
+		LOG_ERR("pm_device_runtime_get() failed: %d", rc);
+		return rc;
+	}
+
+	rc = _acquire(dev);
+	if (rc < 0) {
+		release_power(dev);
+	}
+
+	return rc;
+}
+
+static void _release(const struct device *dev)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
 
@@ -302,6 +338,13 @@ static void release(const struct device *dev)
 
 	k_sem_give(&dev_data->acquired);
 #endif
+}
+
+static void release(const struct device *dev)
+{
+	_release(dev);
+
+	release_power(dev);
 }
 
 static inline uint32_t dev_flash_size(const struct device *dev)
@@ -731,17 +774,17 @@ static int dev_pm_action_cb(const struct device *dev,
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
 #if defined(WITH_DPD)
-		acquire(dev);
+		_acquire(dev);
 		rc = enter_dpd(dev);
-		release(dev);
+		_release(dev);
 #endif
 		break;
 
 	case PM_DEVICE_ACTION_RESUME:
 #if defined(WITH_DPD)
-		acquire(dev);
+		_acquire(dev);
 		rc = exit_dpd(dev);
-		release(dev);
+		_release(dev);
 #endif
 		break;
 

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -659,19 +659,97 @@ static int api_read_jedec_id(const struct device *dev, uint8_t *id)
 }
 #endif /* CONFIG_FLASH_JESD216_API  */
 
+#if defined(WITH_DPD)
+static int enter_dpd(const struct device *const dev)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	int rc = 0;
+
+	if (dev_config->has_dpd) {
+		set_up_xfer(dev, MSPI_TX, dev_config->control_xfer_mode);
+		rc = perform_xfer(dev, SPI_NOR_CMD_DPD);
+
+		if (rc >= 0) {
+			dev_data->enter_dpd_cycle = k_cycle_get_32();
+		}
+	}
+
+	return rc;
+}
+
+static int exit_dpd(const struct device *const dev)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	int rc = 0;
+
+	if (dev_config->has_dpd) {
+		/* When relasing the flash chip from DPD mode, make sure that
+		 * enough time has passed since the DPD command was issued,
+		 * otherwise the request might get ignored by the chip.
+		 * This minimal interval is the sum of the time the flash
+		 * chip needs to enter DPD mode after receiving the DPD
+		 * command (t-enter-dpd in dts) and the time the chip needs
+		 * to be in DPD mode before it can handle a request to exit
+		 * the mode (item 0 in dpd-wakeup-sequence).
+		 */
+		uint32_t min_interval_us = dev_config->t_enter_dpd_us
+					 + dev_config->t_dpdd_us;
+		uint32_t since_enter_cyc = k_cycle_get_32()
+					 - dev_data->enter_dpd_cycle;
+		uint32_t since_enter_us = k_cyc_to_us_floor32(since_enter_cyc);
+
+		if (since_enter_us < min_interval_us) {
+			k_busy_wait(min_interval_us - since_enter_us);
+		}
+
+		/* It is not possible to request the MSPI controller to just
+		 * do a pulse on the CS line, thus even if dpd-wakeup-sequence
+		 * is defined, we just send the RDPD command - this will cause
+		 * the CS line to be asserted and the pulse should always be
+		 * longer than the required tCDRP from dpd-wakeup-sequence as
+		 * that time is usually less than two SCK cycles.
+		 */
+		set_up_xfer(dev, MSPI_TX, dev_config->control_xfer_mode);
+		rc = perform_xfer(dev, SPI_NOR_CMD_RDPD);
+
+		if (rc >= 0) {
+			k_busy_wait(dev_config->t_exit_dpd_us);
+		}
+	}
+
+	return rc;
+}
+#endif /* WITH_DPD */
+
 static int dev_pm_action_cb(const struct device *dev,
 			    enum pm_device_action action)
 {
+	int rc = 0;
+
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
+#if defined(WITH_DPD)
+		acquire(dev);
+		rc = enter_dpd(dev);
+		release(dev);
+#endif
 		break;
+
 	case PM_DEVICE_ACTION_RESUME:
+#if defined(WITH_DPD)
+		acquire(dev);
+		rc = exit_dpd(dev);
+		release(dev);
+#endif
 		break;
+
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return rc;
 }
 
 static int quad_enable_set(const struct device *dev, bool enable)
@@ -1072,6 +1150,18 @@ static int flash_chip_init(const struct device *dev)
 		k_busy_wait(dev_config->reset_recovery_us);
 	}
 
+#if defined(WITH_DPD)
+	/* If the flash chip was not reset, it may remain in DPD mode.
+	 * Make sure to bring it to normal operation.
+	 */
+	dev_data->enter_dpd_cycle = k_cycle_get_32();
+	rc = exit_dpd(dev);
+	if (rc < 0) {
+		LOG_ERR("Failed to exit DPD (%d)", rc);
+		return -EIO;
+	}
+#endif
+
 	if (dev_config->quirks != NULL &&
 	    dev_config->quirks->pre_init != NULL) {
 		rc = dev_config->quirks->pre_init(dev);
@@ -1363,6 +1453,17 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 #define PACKET_DATA_LIMIT(inst) \
 	DT_PROP_OR(DT_INST_BUS(inst), packet_data_limit, 0)
 
+#define INIT_DPD_TIMES(inst) \
+	.t_enter_dpd_us = DT_INST_PROP_OR(inst, t_enter_dpd, 0) \
+			/ NSEC_PER_USEC, \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dpd_wakeup_sequence), \
+		(.t_dpdd_us = DT_INST_PROP_BY_IDX(inst, dpd_wakeup_sequence, 0) \
+			    / NSEC_PER_USEC, \
+		 .t_exit_dpd_us = DT_INST_PROP_BY_IDX(inst, dpd_wakeup_sequence, 2) \
+				/ NSEC_PER_USEC,), \
+		(.t_exit_dpd_us = DT_INST_PROP_OR(inst, t_exit_dpd, 0) \
+				/ NSEC_PER_USEC,))
+
 #if CONFIG_FLASH_MSPI_NOR_DMA_CONTROL_XFER
 #define FLASH_MSPI_NOR_CONTROL_XFER_MODE MSPI_DMA
 #else
@@ -1404,6 +1505,7 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 		.reset_recovery_us = DT_INST_PROP_OR(inst, t_reset_recovery, 0)	\
 				   / NSEC_PER_USEC,				\
 		.transfer_timeout = DT_INST_PROP(inst, transfer_timeout),	\
+		IF_ENABLED(WITH_DPD, (INIT_DPD_TIMES(inst)))			\
 		FLASH_PAGE_LAYOUT_DEFINE(inst)					\
 		.jedec_id = DT_INST_PROP_OR(inst, jedec_id, {0}),		\
 		.quirks = FLASH_QUIRKS(inst),					\
@@ -1424,6 +1526,7 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 					       software_multiperipheral),	\
 		IO_MODE_FLAGS(DT_INST_ENUM_IDX(inst, mspi_io_mode)),		\
 		.initial_soft_reset = DT_INST_PROP(inst, initial_soft_reset),	\
+		.has_dpd = DT_INST_PROP(inst, has_dpd),				\
 		.control_xfer_mode = FLASH_MSPI_NOR_CONTROL_XFER_MODE,		\
 		.data_xfer_mode = FLASH_MSPI_NOR_DATA_XFER_MODE,		\
 	};									\

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -1377,7 +1377,7 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 
 #define FLASH_MSPI_NOR_INST(inst)						\
 	BUILD_ASSERT(!PACKET_DATA_LIMIT(inst) ||				\
-		     FLASH_PAGE_SIZE_INST(inst) <= PACKET_DATA_LIMIT(inst),		\
+		     FLASH_PAGE_SIZE_INST(inst) <= PACKET_DATA_LIMIT(inst),	\
 		"Page size for " DT_NODE_FULL_NAME(DT_DRV_INST(inst))		\
 		" exceeds controller packet data limit");			\
 	SFDP_BUILD_ASSERTS(inst);						\
@@ -1388,8 +1388,8 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),			\
 		.packet_data_limit = DT_PROP_OR(DT_INST_BUS(inst),		\
 						packet_data_limit, 0),		\
-		.flash_size = FLASH_SIZE_INST(inst),					\
-		.page_size = FLASH_PAGE_SIZE_INST(inst),				\
+		.flash_size = FLASH_SIZE_INST(inst),				\
+		.page_size = FLASH_PAGE_SIZE_INST(inst),			\
 		.mspi_id = MSPI_DEVICE_ID_DT_INST(inst),			\
 		.mspi_nor_cfg = MSPI_DEVICE_CONFIG_DT_INST(inst),		\
 		.mspi_control_cfg = FLASH_CONTROL_CMD_CONFIG(inst),		\
@@ -1400,9 +1400,9 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 	IF_ENABLED(WITH_RESET_GPIO,						\
 		(.reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),	\
 		 .reset_pulse_us = DT_INST_PROP_OR(inst, t_reset_pulse, 0)	\
-				 / 1000,))					\
+				 / NSEC_PER_USEC,))				\
 		.reset_recovery_us = DT_INST_PROP_OR(inst, t_reset_recovery, 0)	\
-				   / 1000,					\
+				   / NSEC_PER_USEC,				\
 		.transfer_timeout = DT_INST_PROP(inst, transfer_timeout),	\
 		FLASH_PAGE_LAYOUT_DEFINE(inst)					\
 		.jedec_id = DT_INST_PROP_OR(inst, jedec_id, {0}),		\

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -25,6 +25,9 @@ extern "C" {
 #if DT_ANY_INST_HAS_BOOL_STATUS_OKAY(initial_soft_reset)
 #define WITH_SOFT_RESET 1
 #endif
+#if DT_ANY_INST_HAS_BOOL_STATUS_OKAY(has_dpd)
+#define WITH_DPD 1
+#endif
 
 #define CMD_EXTENSION_NONE    0
 #define CMD_EXTENSION_SAME    1
@@ -88,6 +91,11 @@ struct flash_mspi_nor_config {
 #endif
 	uint32_t reset_recovery_us;
 	uint32_t transfer_timeout;
+#if defined(WITH_DPD)
+	uint32_t t_enter_dpd_us;
+	uint32_t t_exit_dpd_us;
+	uint32_t t_dpdd_us;
+#endif
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	struct flash_pages_layout layout;
 #endif
@@ -106,6 +114,7 @@ struct flash_mspi_nor_config {
 	bool multi_io_cmd        : 1;
 	bool single_io_addr      : 1;
 	bool initial_soft_reset  : 1;
+	bool has_dpd             : 1;
 	enum mspi_xfer_mode control_xfer_mode;
 	enum mspi_xfer_mode data_xfer_mode;
 };
@@ -120,6 +129,9 @@ struct flash_mspi_nor_data {
 	struct flash_mspi_nor_cmd_info cmd_info;
 	struct flash_mspi_nor_switch_info switch_info;
 	const struct mspi_dev_cfg *last_applied_cfg;
+#if defined(WITH_DPD)
+	uint32_t enter_dpd_cycle;
+#endif
 	bool chip_initialized;
 	const struct mspi_dev_cfg *read_cfg;
 	struct mspi_dev_cfg mspi_dev_read_cfg;


### PR DESCRIPTION
Backport 39b543a63e63e2122f1c72cdef6dd1eb27a84148~3..39b543a63e63e2122f1c72cdef6dd1eb27a84148 from #4086.