### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -352,7 +352,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: cd44ed9674d115457fd620d5a43741576f328e4b
+      revision: 309d02c0df8625c52a6abc2fd95dc77fe80c163a
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 47bd5b4ebd357ba637be0f2b092e1c0d370eea2f

--- a/west.yml
+++ b/west.yml
@@ -352,7 +352,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: f8690d57f10d2712b374d0661e1515b0a483855b
+      revision: b452ce26db23a79fe50d7307adabfff3a75a53ad
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 47bd5b4ebd357ba637be0f2b092e1c0d370eea2f

--- a/west.yml
+++ b/west.yml
@@ -352,7 +352,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 158b9710d6e10c57b2c623f8f4178f0bbc85c23f
+      revision: f8690d57f10d2712b374d0661e1515b0a483855b
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 47bd5b4ebd357ba637be0f2b092e1c0d370eea2f

--- a/west.yml
+++ b/west.yml
@@ -352,7 +352,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: b452ce26db23a79fe50d7307adabfff3a75a53ad
+      revision: cd44ed9674d115457fd620d5a43741576f328e4b
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 47bd5b4ebd357ba637be0f2b092e1c0d370eea2f


### PR DESCRIPTION
This PR brings bsim hw models to latest revision to fix a couple of issues in the HW models.

```
commit efccda7cbd59a82e8b3333e81bee8159d383940e
Author: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
Date:   Wed May 27 14:31:15 2026 +0200

    manifest: Update nRF hw models to latest
    
    Update the HW models module to:
    309d02c0df8625c52a6abc2fd95dc77fe80c163a
    
    Including the following:
    309d02c RADIO: Minor Tx timing refactoring (no functional change)
    40288ee RADIO: Fix CodedPhy Tx END/PHYEND timing
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
    (cherry picked from commit 8dacbfa7bc0b4c6bc372522b34eeb5116d9abf84)

commit 2aefad6841476d279f51f0badc78cf79b71ebccb
Author: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
Date:   Tue May 19 09:21:20 2026 +0200

    manifest: Update nRF hw models to latest
    
    Update the HW models module to:
    cd44ed9674d115457fd620d5a43741576f328e4b
    
    Including the following:
    cd44ed9 hal: use original nrf_uicr.h
    9d93e6c 54 CCM: Remove not applicate note
    eaa16db 54 FICR: Set INFO.PART & RRAM from NHW_config instead of same
            value
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
    (cherry picked from commit 0f9ccc67cc686f5ecaf99e5ba40c79a11c31d8d0)

commit b1394f1a10f28998acd84f13f5f0c6490837c76f
Author: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
Date:   Wed May 6 13:06:57 2026 +0200

    manifest: Update nRF hw models to latest
    
    Update the HW models module to:
    b452ce26db23a79fe50d7307adabfff3a75a53ad
    
    Including the following:
    b452ce2 RADIO: Fix CodedPhy correct timing of FEC2 portion
    5efa1da RADIO: Fix comments in RADIO_timings.c
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
    (cherry picked from commit 659c1178419103d762f3b50dee4edf117555618a)

commit 5634c955bd9e14159123500703f40dac08fb2ced
Author: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
Date:   Fri Apr 24 13:57:59 2026 +0200

    manifest: Update nRF hw models to latest
    
    Update the HW models module to:
    f8690d57f10d2712b374d0661e1515b0a483855b
    
    Including the following:
    f8690d5 RADIO: minor code refactor
    68f93da RADIO: Minor refactoring of Tx starting state
    df5b46e RADIO: Fix STATUS register values for TX and TXDISABLE states
    af08d40 RADIO: Ensure PLL code also builds with nrfx <4.1
    ec3fe6b nrf_radio hal replacement: Add PLLEN TASK support
    69aeb50 RADIO: Model PLLEN/READY
    036a903 RADIO: Change ramup timings storage
    6676d0f RADIO: Support interrupts causes over 32nd
    2317660 RADIO: remove redundant state handling code
    87f58fa RADIO: Remove redundant statement
    2e5b095 RADIO: Remove not applicable note
    659efdf nrf_radio hal: Add missing SOFTRESET subscribe handling
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
    (cherry picked from commit 22596d853f1330e35e38a302a2ab54cfe5ea946f)
```
