### PR TITLE
[nrf fromlist] drivers: clock_control: Add handling of missing NRF_BI…

### DIFF
--- a/drivers/clock_control/clock_control_nrf_lfclk.c
+++ b/drivers/clock_control/clock_control_nrf_lfclk.c
@@ -332,8 +332,11 @@ static int lfclk_init(const struct device *dev)
 
 	lfosc_mode = nrf_bicr_lfosc_mode_get(BICR);
 
-	if (lfosc_mode == NRF_BICR_LFOSC_MODE_UNCONFIGURED ||
-	    lfosc_mode == NRF_BICR_LFOSC_MODE_DISABLED) {
+	if (lfosc_mode == NRF_BICR_LFOSC_MODE_UNCONFIGURED
+#if NRF_BICR_HAS_LFOSC_LFXOCONFIG_DISABLED
+	    || lfosc_mode == NRF_BICR_LFOSC_MODE_DISABLED
+#endif
+	) {
 		dev_data->max_accuracy = LFCLK_HFXO_ACCURACY;
 	} else {
 		ret = lfosc_get_accuracy(&dev_data->max_accuracy);
@@ -343,6 +346,7 @@ static int lfclk_init(const struct device *dev)
 		}
 
 		switch (lfosc_mode) {
+#if NRF_BICR_HAS_LFOSC_LFXOCONFIG_CRYSTAL
 		case NRF_BICR_LFOSC_MODE_CRYSTAL:
 			clock_option = &clock_options[dev_data->clock_options_cnt];
 			clock_option->accuracy = dev_data->max_accuracy;
@@ -356,7 +360,31 @@ static int lfclk_init(const struct device *dev)
 			clock_option->src = NRFS_CLOCK_SRC_LFCLK_XO_PIERCE_HP;
 			dev_data->clock_options_cnt++;
 			break;
+#endif
+#if NRF_BICR_HAS_LFOSC_LFXOCONFIG_PIERCE
+		case NRF_BICR_LFOSC_MODE_PIERCE:
+			clock_option = &clock_options[dev_data->clock_options_cnt];
+			clock_option->accuracy = dev_data->max_accuracy;
+			clock_option->precision = 0;
+			clock_option->src = NRFS_CLOCK_SRC_LFCLK_XO_PIERCE;
+			dev_data->clock_options_cnt++;
 
+			clock_option = &clock_options[dev_data->clock_options_cnt];
+			clock_option->accuracy = dev_data->max_accuracy;
+			clock_option->precision = 1;
+			clock_option->src = NRFS_CLOCK_SRC_LFCLK_XO_PIERCE_HP;
+			dev_data->clock_options_cnt++;
+			break;
+#endif
+#if NRF_BICR_HAS_LFOSC_LFXOCONFIG_PIXO
+		case NRF_BICR_LFOSC_MODE_PIXO:
+			clock_option = &clock_options[dev_data->clock_options_cnt];
+			clock_option->accuracy = dev_data->max_accuracy;
+			clock_option->precision = 0;
+			clock_option->src = NRFS_CLOCK_SRC_LFCLK_XO_PIXO;
+			dev_data->clock_options_cnt++;
+			break;
+#endif
 		case NRF_BICR_LFOSC_MODE_EXTSINE:
 			clock_option = &clock_options[dev_data->clock_options_cnt];
 			clock_option->accuracy = dev_data->max_accuracy;

--- a/tests/drivers/clock_control/nrf_clock_control/src/main.c
+++ b/tests/drivers/clock_control/nrf_clock_control/src/main.c
@@ -17,8 +17,15 @@ struct test_clk_context {
 	size_t clk_specs_size;
 };
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF_HSFLL_LOCAL) ||                                               \
-	defined(CONFIG_CLOCK_CONTROL_NRF_IRON_HSFLL_LOCAL)
+#if defined(CONFIG_TEST_HSFLL_APP) || defined(CONFIG_TEST_HSFLL_RAD)
+#if DT_NODE_EXISTS(DT_NODELABEL(cpuapp_hsfll))
+#define LOCAL_HSFLL_NODE DT_NODELABEL(cpuapp_hsfll)
+#elif DT_NODE_EXISTS(DT_NODELABEL(cpurad_hsfll))
+#define LOCAL_HSFLL_NODE DT_NODELABEL(cpurad_hsfll)
+#else
+#error "No local HSFLL node defined."
+#endif
+#define LOCAL_HSFLL_BASE_FREQUENCY DT_PROP(LOCAL_HSFLL_NODE, clock_frequency)
 const struct nrf_clock_spec test_clk_specs_hsfll[] = {
 	{
 		.frequency = MHZ(128),
@@ -26,7 +33,7 @@ const struct nrf_clock_spec test_clk_specs_hsfll[] = {
 		.precision = NRF_CLOCK_CONTROL_PRECISION_DEFAULT,
 	},
 	{
-		.frequency = MHZ(320),
+		.frequency = LOCAL_HSFLL_BASE_FREQUENCY,
 		.accuracy = 0,
 		.precision = NRF_CLOCK_CONTROL_PRECISION_DEFAULT,
 	},
@@ -34,6 +41,14 @@ const struct nrf_clock_spec test_clk_specs_hsfll[] = {
 		.frequency = MHZ(64),
 		.accuracy = 0,
 		.precision = NRF_CLOCK_CONTROL_PRECISION_DEFAULT,
+	},
+};
+
+static const struct test_clk_context local_hsfll_test_clk_contexts[] = {
+	{
+		.clk_dev = DEVICE_DT_GET(LOCAL_HSFLL_NODE),
+		.clk_specs = test_clk_specs_hsfll,
+		.clk_specs_size = ARRAY_SIZE(test_clk_specs_hsfll),
 	},
 };
 #endif
@@ -83,26 +98,6 @@ static const struct test_clk_context invalid_fll16m_test_clk_contexts[] = {
 		.clk_dev = DEVICE_DT_GET(DT_NODELABEL(fll16m)),
 		.clk_specs = invalid_test_clk_specs_fll16m,
 		.clk_specs_size = ARRAY_SIZE(invalid_test_clk_specs_fll16m),
-	},
-};
-#endif
-
-#if defined(CONFIG_TEST_HSFLL_APP)
-static const struct test_clk_context cpuapp_hsfll_test_clk_contexts[] = {
-	{
-		.clk_dev = DEVICE_DT_GET(DT_NODELABEL(cpuapp_hsfll)),
-		.clk_specs = test_clk_specs_hsfll,
-		.clk_specs_size = ARRAY_SIZE(test_clk_specs_hsfll),
-	},
-};
-#endif
-
-#if defined(CONFIG_TEST_HSFLL_RAD)
-static const struct test_clk_context cpurad_hsfll_test_clk_contexts[] = {
-	{
-		.clk_dev = DEVICE_DT_GET(DT_NODELABEL(cpurad_hsfll)),
-		.clk_specs = test_clk_specs_hsfll,
-		.clk_specs_size = ARRAY_SIZE(test_clk_specs_hsfll),
 	},
 };
 #endif
@@ -282,8 +277,8 @@ ZTEST(nrf2_clock_control, test_cpuapp_hsfll_control)
 	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_HSFLL_APP);
 #if defined(CONFIG_TEST_HSFLL_APP)
 	TC_PRINT("APPLICATION DOMAIN HSFLL test\n");
-	test_clock_control_request(cpuapp_hsfll_test_clk_contexts,
-				   ARRAY_SIZE(cpuapp_hsfll_test_clk_contexts));
+	test_clock_control_request(local_hsfll_test_clk_contexts,
+				   ARRAY_SIZE(local_hsfll_test_clk_contexts));
 #endif
 }
 
@@ -342,8 +337,8 @@ ZTEST(nrf2_clock_control, test_cpurad_hsfll_control)
 	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_HSFLL_RAD);
 #if defined(CONFIG_TEST_HSFLL_RAD)
 	TC_PRINT("RADIO DOMAIN HSFLL test\n");
-	test_clock_control_request(cpurad_hsfll_test_clk_contexts,
-				   ARRAY_SIZE(cpurad_hsfll_test_clk_contexts));
+	test_clock_control_request(local_hsfll_test_clk_contexts,
+				   ARRAY_SIZE(local_hsfll_test_clk_contexts));
 #endif
 }
 


### PR DESCRIPTION
…CR LFOSC modes

Add handling of missing NRF_BICR LFOSC modes MODE_PIERCE and MODE_PIXO and filter out unsupported modes with preprocessor macros provided by nrfx.

Upstream PR #: 110258