### PR TITLE
[nrf fromtree] soc: nordic: Update nRF5340 reset group.

### DIFF
--- a/soc/nordic/soc.yml
+++ b/soc/nordic/soc.yml
@@ -230,7 +230,6 @@ runners:
               - nrf52840
           - qualifiers:
               - nrf5340/cpunet
-          - qualifiers:
               - nrf5340/cpuapp
               - nrf5340/cpuapp/ns
           - qualifiers:


### PR DESCRIPTION
All cores should be flashed before reset is applied. This avoids situations where appprotect is enabled before flashing is completed.

Signed-off-by: Dag Erik Gjørvad <dag.erik.gjorvad@nordicsemi.no>

Upstream PR #: 110269