### PR TITLE
nrf71: Increase RAM to accommodate Wi-Fi when TF-M is enabled

### DIFF
--- a/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuflpr.dts
+++ b/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuflpr.dts
@@ -22,13 +22,6 @@
 	};
 };
 
-/* RAM03 is single cycle access for FLPR core while RAM01 is 2 cycle access */
-&ram03_sram {
-	status = "okay";
-	reg = <0x200e0000 DT_SIZE_K(120)>;
-	ranges = <0x0 0x200e0000 0x1e000>;
-};
-
 &cpuflpr_mram {
 	partitions {
 		#address-cells = <1>;

--- a/dts/riscv/nordic/nrf7120_enga_cpuflpr.dtsi
+++ b/dts/riscv/nordic/nrf7120_enga_cpuflpr.dtsi
@@ -32,6 +32,23 @@ clic: &cpuflpr_clic {};
 		compatible = "simple-bus";
 		interrupt-parent = <&cpuflpr_clic>;
 		ranges;
+
+		/* RAM02/03 is single cycle access for FLPR core while RAM00/01 is 2 cycle access */
+		cpuflpr_sram: memory@200e0000 {
+			compatible = "mmio-sram";
+			reg = <0x200e0000 DT_SIZE_K(120)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x200e0000 DT_SIZE_K(120)>;
+
+			ram03_sram: memory@0 {
+				compatible = "mmio-sram";
+				reg = <0x0 DT_SIZE_K(120)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges = <0x0 0x0 DT_SIZE_K(120)>;
+			};
+		};
 	};
 };
 

--- a/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
@@ -45,7 +45,7 @@
 		 * header flash_layout.h of the relevant platform. Any updates in the layout
 		 * needs to happen both in the flash_layout.h and in this file at the same time.
 		 */
-		slot0_partition: partition@0 {
+		slot0_s_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000000 DT_SIZE_K(384)>;

--- a/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
@@ -16,7 +16,7 @@
  */
 
 &cpuapp_sram {
-	sram0_s: image_s@0 {
+	sram0_s: sram@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Secure image memory */
@@ -24,7 +24,7 @@
 		ranges = <0x0 0x0 DT_SIZE_K(96)>;
 	};
 
-	sram0_ns: image_ns@18000 {
+	sram0_ns: sram@18000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Non-Secure image memory */

--- a/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
@@ -56,7 +56,7 @@
 		 * header flash_layout.h of the relevant platform. Any updates in the layout
 		 * needs to happen both in the flash_layout.h and in this file at the same time.
 		 */
-		slot0_partition: partition@0 {
+		slot0_s_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000000 DT_SIZE_K(512)>;

--- a/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
@@ -15,7 +15,7 @@
  * needs to happen both in the flash_layout.h and in this file at the same time.
  */
 &cpuapp_sram {
-	sram0_s: image_s@0 {
+	sram0_s: sram@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Secure image memory */
@@ -23,7 +23,7 @@
 		ranges = <0x0 0x0 DT_SIZE_K(128)>;
 	};
 
-	sram0_ns: image_ns@20000 {
+	sram0_ns: sram@20000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Non-Secure image memory */

--- a/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
@@ -58,7 +58,7 @@
 		 * header flash_layout.h of the relevant platform. Any updates in the layout
 		 * needs to happen both in the flash_layout.h and in this file at the same time.
 		 */
-		slot0_partition: partition@0 {
+		slot0_s_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000000 DT_SIZE_K(512)>;

--- a/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
@@ -17,7 +17,7 @@
  * needs to happen both in the flash_layout.h and in this file at the same time.
  */
 &cpuapp_sram {
-	sram0_s: image_s@0 {
+	sram0_s: sram@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Secure image memory */
@@ -25,7 +25,7 @@
 		ranges = <0x0 0x0 DT_SIZE_K(256)>;
 	};
 
-	sram0_ns: image_ns@40000 {
+	sram0_ns: sram@40000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Non-Secure image memory */

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -57,7 +57,7 @@
 		 * needs to happen both in the flash_layout.h and in this file at the same time.
 		 */
 
-		slot0_partition: partition@0 {
+		slot0_s_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000000 DT_SIZE_K(512)>;

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -17,7 +17,7 @@
  * needs to happen both in the flash_layout.h and in this file at the same time.
  */
 &cpuapp_sram {
-	sram0_s: image_s@0 {
+	sram0_s: sram@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Secure image memory */
@@ -25,7 +25,7 @@
 		ranges = <0x0 0x0 DT_SIZE_K(256)>;
 	};
 
-	sram0_ns: image_ns@40000 {
+	sram0_ns: sram@40000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Non-Secure image memory */

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -8,10 +8,13 @@
 
 /*
  * Default SRAM planning when building for nRF7120 with ARM TrustZone-M support
- * - Lowest 256 kB SRAM allocated to Secure image (sram0_s).
- * - Upper 256 kB SRAM allocated to Non-Secure image (sram0_ns).
+ * - Lowest 128 kB in RAM00 allocated to Secure RAM (sram0_s).
+ * - Upper 384 kB in RAM00 allocated to Non-Secure RAM (sram00_ns).
+ * - 256 kB SRAM in RAM01 allocated to Non-Secure RAM (sram01_ns).
+ * - 128 kB SRAM in RAM02 allocated to Non-Secure RAM (sram02_ns).
+ * - 120 kB SRAM in RAM03 allocated to Non-Secure RAM (sram03_ns).
  *
- * cpuapp_sram has 512 kB of volatile memory (SRAM).
+ * cpuapp_sram has 1016 kB of volatile memory (SRAM).
  * This static layout needs to be the same with the upstream TF-M layout in the
  * header flash_layout.h of the relevant platform. Any updates in the layout
  * needs to happen both in the flash_layout.h and in this file at the same time.
@@ -20,17 +23,49 @@
 	sram0_s: sram@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		/* Secure image memory */
-		reg = <0x0 DT_SIZE_K(256)>;
-		ranges = <0x0 0x0 DT_SIZE_K(256)>;
+		/* Secure RAM */
+		reg = <0x0 DT_SIZE_K(128)>; /* 0x2000_0000 */
+		ranges = <0x0 0x0 DT_SIZE_K(128)>;
 	};
 
-	sram0_ns: sram@40000 {
+	sram0_ns: sram@20000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		/* Non-Secure image memory */
-		reg = <0x40000 DT_SIZE_K(256)>;
-		ranges = <0x0 0x40000 DT_SIZE_K(256)>;
+		/* Non-Secure RAM */
+		reg = <0x20000 DT_SIZE_K(888)>; /* 0x2002_0000 */
+		ranges = <0x0 0x20000 DT_SIZE_K(888)>;
+
+		sram00_ns: sram0_ns@0 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			/* Non-Secure RAM */
+			reg = <0x0 DT_SIZE_K(384)>; /* 0x2002_0000 */
+			ranges = <0x0 0x0 DT_SIZE_K(384)>;
+		};
+
+		sram01_ns: sram0_ns@60000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			/* Non-Secure RAM */
+			reg = <0x60000 DT_SIZE_K(256)>; /* 0x2008_0000 */
+			ranges = <0x0 0x60000 DT_SIZE_K(256)>;
+		};
+
+		sram02_ns: sram0_ns@a0000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			/* Non-Secure RAM */
+			reg = <0xa0000 DT_SIZE_K(128)>; /* 0x200C_0000 */
+			ranges = <0x0 0xa0000 DT_SIZE_K(128)>;
+		};
+
+		sram03_ns: sram0_ns@c0000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			/* Non-Secure RAM */
+			reg = <0xc0000 DT_SIZE_K(120)>; /* 0x200E_0000 */
+			ranges = <0x0 0xc0000 DT_SIZE_K(120)>;
+		};
 	};
 };
 

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -151,34 +151,42 @@
 
 		cpuapp_sram: memory@20000000 {
 			compatible = "mmio-sram";
-			reg = <0x20000000 DT_SIZE_K(512)>;
+			reg = <0x20000000 DT_SIZE_K(1016)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20000000 0x80000>;
-		};
+			ranges = <0x0 0x20000000 0xfe000>;
 
-		ram01_sram: memory@20080000 {
-			compatible = "mmio-sram";
-			reg = <0x20080000 DT_SIZE_K(256)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x20080000 0x40000>;
-		};
+			ram00_sram: memory@0 {
+				compatible = "mmio-sram";
+				reg = <0x0 DT_SIZE_K(512)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges = <0x0 0x0 DT_SIZE_K(512)>;
+			};
 
-		ram02_sram: memory@200c0000 {
-			compatible = "mmio-sram";
-			reg = <0x200c0000 DT_SIZE_K(128)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x200c0000 0x20000>;
-		};
+			ram01_sram: memory@80000 {
+				compatible = "mmio-sram";
+				reg = <0x80000 DT_SIZE_K(256)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges = <0x0 0x80000 DT_SIZE_K(256)>;
+			};
 
-		ram03_sram: memory@200e0000 {
-			compatible = "mmio-sram";
-			reg = <0x200e0000 DT_SIZE_K(120)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x200e0000 0x1e000>;
+			ram02_sram: memory@c0000 {
+				compatible = "mmio-sram";
+				reg = <0xc0000 DT_SIZE_K(128)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges = <0x0 0xc0000 DT_SIZE_K(128)>;
+			};
+
+			ram03_sram: memory@e0000 {
+				compatible = "mmio-sram";
+				reg = <0xe0000 DT_SIZE_K(120)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges = <0x0 0xe0000 DT_SIZE_K(120)>;
+			};
 		};
 
 		/* Wi-Fi ROM regions */

--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -166,8 +166,8 @@ static void wifi_setup(void)
 		(LRCCONF_POWERON_MAIN_AlwaysOn << LRCCONF_POWERON_MAIN_Pos);
 	NRF_WIFICORE_LMAC_VPR->INITPC = NRF_WICR->RESERVED[0];
 	NRF_WIFICORE_LMAC_VPR->CPURUN = (VPR_CPURUN_EN_Running << VPR_CPURUN_EN_Pos);
-#endif
 }
+#endif
 #endif
 
 void soc_early_init_hook(void)

--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -94,8 +94,8 @@ struct mpc_region_override {
 	}
 
 static const struct mpc_region_override mpc00_region_overrides[] = {
-	/* Make RAM_00/01/02 (AMBIX00 + AMBIX03) accessible to all domains */
-	MPC_REGION_OVERRIDE_INIT(0x20000000, 0x200E0000, 0, 0),
+	/* Make RAM_00/01/02/03 (AMBIX00 + AMBIX03) accessible to all domains */
+	MPC_REGION_OVERRIDE_INIT(0x20000000, 0x200FE000, 0, 0),
 	/* Make MRAM accessible to all domains */
 	MPC_REGION_OVERRIDE_INIT(0x00000000, 0x01000000, 0, 0),
 #if CONFIG_SOC_NRF71_WIFI_DAP
@@ -105,8 +105,8 @@ static const struct mpc_region_override mpc00_region_overrides[] = {
 };
 
 static const struct mpc_region_override mpc03_region_overrides[] = {
-	/* Make RAM_02 (AMBIX03) accessible to the Wi-Fi domain for IPC */
-	MPC_REGION_OVERRIDE_INIT(0x200C0000, 0x200E0000, 0, 0),
+	/* Make RAM_02/03 (AMBIX03)  accessible to all domains */
+	MPC_REGION_OVERRIDE_INIT(0x200C0000, 0x200FE000, 0, 0),
 };
 
 static void set_mpc_region_override(NRF_MPC_Type *mpc,


### PR DESCRIPTION
*  Increase RAM to accommodate Wi-Fi when TF-M is enabled
* Build error with TF-M

manifest-pr-skip