### PR TITLE
[Backport ncs-v3.4-branch] bluetooth: mesh: fixes for 3.4.0 release

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -201,6 +201,7 @@ config BT_BUF_EVT_DISCARDABLE_SIZE
 	default $(UINT8_MAX) if BT_CLASSIC
 	# Le Advertising Report event
 	default 43 if !BT_EXT_ADV
+	default 58 if BT_EXT_ADV && BT_MESH
 	default BT_BUF_EVT_RX_SIZE if BT_EXT_ADV
 	help
 	  Maximum support discardable HCI event size of buffers in the separate

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -202,7 +202,7 @@ static void subnet_keys_destroy(struct bt_mesh_subnet_keys *key)
 #if defined(CONFIG_BT_MESH_GATT_PROXY)
 	bt_mesh_key_destroy(&key->identity);
 #endif
-#if defined(CONFIG_BT_MESH_V1d1)
+#if defined(CONFIG_BT_MESH_PRIV_BEACONS)
 	bt_mesh_key_destroy(&key->priv_beacon);
 #endif
 }


### PR DESCRIPTION
Backport 608dbfd6068ad550045faafb29a48563e83e4013~2..608dbfd6068ad550045faafb29a48563e83e4013 from #4152.