### PR TITLE
drivers: spi: nrfx_spim: support builds without multithreading

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -15,7 +15,11 @@ LOG_MODULE_DECLARE(spi_nrfx_spim);
 struct driver_data {
 	struct spi_nrfx_common_data common;
 	struct spi_context ctx;
+#ifdef CONFIG_MULTITHREADING
 	struct k_sem wake_sem;
+#else
+	atomic_t woken_up;
+#endif
 };
 
 struct driver_config {
@@ -83,7 +87,28 @@ static void spim_wake_handler(const struct device *dev)
 {
 	struct driver_data *dev_data = dev->data;
 
+#ifdef CONFIG_MULTITHREADING
 	k_sem_give(&dev_data->wake_sem);
+#else
+	atomic_set(&dev_data->woken_up, 1);
+#endif
+}
+
+static void spim_wait_for_wake(struct driver_data *dev_data)
+{
+#ifdef CONFIG_MULTITHREADING
+	(void)k_sem_take(&dev_data->wake_sem, K_FOREVER);
+#else
+	unsigned int key = irq_lock();
+
+	while (!atomic_get(&dev_data->woken_up)) {
+		k_cpu_atomic_idle(key);
+		key = irq_lock();
+	}
+
+	atomic_set(&dev_data->woken_up, 0);
+	irq_unlock(key);
+#endif
 }
 
 static void spim_evt_handler(const struct device *dev, nrfx_spim_event_t *evt)
@@ -130,7 +155,7 @@ static int transceive(const struct device *dev,
 	dev_data->ctx.config = spi_cfg;
 
 	spi_nrfx_spim_common_wake_start(dev, spim_wake_handler);
-	k_sem_take(&dev_data->wake_sem, K_FOREVER);
+	spim_wait_for_wake(dev_data);
 
 	spi_nrfx_spim_common_cs_set(dev, spi_cfg);
 	transfer_start(dev);
@@ -213,8 +238,6 @@ static int driver_init(const struct device *dev)
 		return ret;
 	}
 
-	k_sem_init(&dev_data->wake_sem, 0, 1);
-
 	spi_context_unlock_unconditionally(&dev_data->ctx);
 
 	return pm_device_driver_init(dev, spi_nrfx_spim_common_pm_action);
@@ -237,6 +260,10 @@ static int driver_deinit(const struct device *dev)
 		IF_ENABLED(									\
 			CONFIG_MULTITHREADING,							\
 			(SPI_CONTEXT_INIT_SYNC(CONCAT(data, inst), ctx),)			\
+		)										\
+		IF_ENABLED(									\
+			CONFIG_MULTITHREADING,							\
+			(.wake_sem = Z_SEM_INITIALIZER(CONCAT(data, inst).wake_sem, 0, 1),)	\
 		)										\
 	};											\
 												\


### PR DESCRIPTION
## Summary

- Fix linker errors (`undefined reference to z_impl_k_sem_init`) when `spi_nrfx_spim` is used with `CONFIG_MULTITHREADING=n`.
- Align wake synchronization with `spi_nrfx_spis`: use `k_sem` only when multithreading is enabled; otherwise use an atomic flag and `irq_lock`/`k_cpu_atomic_idle`.

## Problem

After the nrf_spim driver refactor, `spi_nrfx_spim.c` always called `k_sem_init`/`k_sem_take`/`k_sem_give` on `wake_sem`. With `CONFIG_MULTITHREADING=n` (e.g. Matter MCUboot on nRF54 with external SPI NOR), `kernel/sem.c` is not linked and builds fail.

## Test plan

- [ ] Build Matter MCUboot child image for `nrf54lm20dk/nrf54lm20a/cpuapp` (sysbuild) with `CONFIG_MULTITHREADING=n` and `CONFIG_SPI_NOR=y`.
- [ ] Build a sample using `spi_nrfx_spim` with `CONFIG_MULTITHREADING=y` (no functional regression).
- [ ] CI: relevant `tests/drivers/spi` on Nordic boards if available.