### PR TITLE
[nrf noup] tests: drivers: spi: add nrfx SPIM no-multithreading build test

### DIFF
--- a/tests/drivers/spi/spi_nrfx_spim_no_multithreading/CMakeLists.txt
+++ b/tests/drivers/spi/spi_nrfx_spim_no_multithreading/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(spi_nrfx_spim_no_multithreading)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/spi/spi_nrfx_spim_no_multithreading/prj.conf
+++ b/tests/drivers/spi/spi_nrfx_spim_no_multithreading/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_SPI=y

--- a/tests/drivers/spi/spi_nrfx_spim_no_multithreading/src/main.c
+++ b/tests/drivers/spi/spi_nrfx_spim_no_multithreading/src/main.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(spi00), okay)
+
+static const struct device *const spi_bus = DEVICE_DT_GET(DT_NODELABEL(spi00));
+
+int main(void)
+{
+	if (!device_is_ready(spi_bus)) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+#else
+#error "This test requires an enabled spi00 (nordic,nrf-spim) devicetree node"
+#endif

--- a/tests/drivers/spi/spi_nrfx_spim_no_multithreading/testcase.yaml
+++ b/tests/drivers/spi/spi_nrfx_spim_no_multithreading/testcase.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - drivers
+    - spi
+  filter: dt_compat_enabled("nordic,nrf-spim")
+tests:
+  drivers.spi.nrfx_spim.no_multithreading:
+    build_only: true
+    extra_configs:
+      - CONFIG_MULTITHREADING=n
+    platform_allow:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54lm20dk/nrf54lm20a/cpuapp


### PR DESCRIPTION
## Summary

Adds a build-only Twister test (`drivers.spi.nrfx_spim.no_multithreading`) that links the `nordic,nrf-spim` driver with `CONFIG_MULTITHREADING=n`, matching MCUboot-style images (e.g. Matter sysbuild MCUboot on nRF54 with external SPI NOR).

This catches linker failures such as `undefined reference to z_impl_k_sem_init` / `z_impl_k_sem_give` when SPIM wake synchronization uses kernel semaphores without multithreading enabled.

## Related

- Driver fix: https://github.com/nrfconnect/sdk-zephyr/pull/4165

CI for this test is expected to fail until #4165 is merged (or the branch is rebased on top of it).

## Test plan

- [ ] `./scripts/twister -T tests/drivers/spi/spi_nrfx_spim_no_multithreading -p nrf54lm20dk/nrf54lm20a/cpuapp --build-only`
- [ ] Verify link succeeds after #4165 is in the tree