### PR TITLE
[nrf fromtree] tests: drivers: uart_elementary: Align nRF7120 cpuflpr…

### DIFF
--- a/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuflpr.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuflpr.overlay
@@ -7,19 +7,19 @@
 &pinctrl {
 	uart21_default: uart21_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 10)>,
-				<NRF_PSEL(UART_RX, 1, 11)>,
-				<NRF_PSEL(UART_RTS, 1, 8)>,
-				<NRF_PSEL(UART_CTS, 1, 9)>;
+			psels = <NRF_PSEL(UART_TX, 1, 13)>,
+				<NRF_PSEL(UART_RX, 1, 15)>,
+				<NRF_PSEL(UART_RTS, 1, 02)>,
+				<NRF_PSEL(UART_CTS, 1, 03)>;
 		};
 	};
 
 	uart21_sleep: uart21_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 10)>,
-				<NRF_PSEL(UART_RX, 1, 11)>,
-				<NRF_PSEL(UART_RTS, 1, 8)>,
-				<NRF_PSEL(UART_CTS, 1, 9)>;
+			psels = <NRF_PSEL(UART_TX, 1, 13)>,
+				<NRF_PSEL(UART_RX, 1, 15)>,
+				<NRF_PSEL(UART_RTS, 1, 02)>,
+				<NRF_PSEL(UART_CTS, 1, 03)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
… pins with cpuapp

The cpuflpr overlay uses different pins than the cpuapp overlay for the same UART peripheral. The CI FPGA has the loopback wired for the cpuapp pins, causing the single-port loopback test to fail on cpuflpr.


(cherry picked from commit 21d1922f54d2a5bc1096273f0dd9f42917a1bbf0)