### PR TITLE
[Backport ncs-v3.4-branch] [nrf fromtree] soc: nordic: Update nRF5340 reset group.

### DIFF
--- a/soc/nordic/soc.yml
+++ b/soc/nordic/soc.yml
@@ -230,7 +230,6 @@ runners:
               - nrf52840
           - qualifiers:
               - nrf5340/cpunet
-          - qualifiers:
               - nrf5340/cpuapp
               - nrf5340/cpuapp/ns
           - qualifiers:


### PR DESCRIPTION
Backport 590c323209ab5b7bfeef4098b318f9ce83d8d0fc from #4146.