### PR TITLE
[nrf fromlist] soc: nordic: common: vpr: Add nrf92 dependency to slee…

### DIFF
--- a/soc/nordic/common/vpr/Kconfig
+++ b/soc/nordic/common/vpr/Kconfig
@@ -39,7 +39,7 @@ config NORDIC_VPR_DEEPSLEEP
 
 config NORDIC_VPR_HIBERNATE
 	bool "Hibernation"
-	depends on !SOC_NRF54H20
+	depends on !SOC_NRF54H20 && !SOC_SERIES_NRF92
 	help
 	  It has the lowest power consumption and it must be used to reach less than 5 uA in
 	  the system-on-idle state on targets other than nRF54H20. It has slightly longer


### PR DESCRIPTION
…p mode

Like nrf54h20, nrf92 series must not use hibernate sleep mode.

Signed-off-by: Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>

Upstream PR #: 110734