### PR TITLE
[Backport ncs-v3.4-branch] [nrf noup] soc: nrf54h: work around missing power domain handling

### DIFF
--- a/soc/nordic/nrf54h/Kconfig
+++ b/soc/nordic/nrf54h/Kconfig
@@ -105,6 +105,11 @@ config SOC_NRF54H20_PM_S2RAM_OVERRIDE
 	help
 	  Override Nordic s2ram implementation.
 
+config SOC_NRF54H20_DISABLE_ALL_GPIO_RETENTION_WORKAROUND
+	bool "Disable all GPIO pin retention on boot"
+	default y
+	depends on SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD
+
 config SOC_NRF54H20_CPURAD
 	select SOC_NRF54H20_CPURAD_COMMON
 

--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -15,6 +15,7 @@
 #include <zephyr/logging/log_frontend_stmesp.h>
 #endif
 
+#include <hal/nrf_gpio.h>
 #include <hal/nrf_hsfll.h>
 #include <hal/nrf_lrcconf.h>
 #include <hal/nrf_spu.h>
@@ -133,6 +134,17 @@ void soc_early_init_hook(void)
 	     DT_NODE_HAS_STATUS(DT_NODELABEL(nfct), reserved)) &&
 	    DT_PROP_OR(DT_NODELABEL(nfct), nfct_pins_as_gpios, 0)) {
 		nrf_nfct_pad_config_enable_set(NRF_NFCT, false);
+	}
+
+	/* This is a workaround for not yet having upstream patches for properly handling
+	 * pin retention. It should be removed as part of the next upmerge.
+	 */
+	if (IS_ENABLED(CONFIG_SOC_NRF54H20_DISABLE_ALL_GPIO_RETENTION_WORKAROUND)) {
+		NRF_GPIO_Type *gpio_regs[GPIO_COUNT] = GPIO_REG_LIST;
+
+		for (int i = 0; i < NRFX_ARRAY_SIZE(gpio_regs); i++) {
+			nrf_gpio_port_retain_set(gpio_regs[i], 0);
+		}
 	}
 }
 


### PR DESCRIPTION
Backport 66bf60c0ceae83db0e9e094b5465ee1a25ccf7f4 from #4120.