### PR TITLE
[Backport ncs-v3.4-branch] [nrf noup] drivers: rram: Mirror dts support from NVMC

### DIFF
--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -54,10 +54,12 @@ LOG_MODULE_REGISTER(flash_nrf_rram, CONFIG_FLASH_LOG_LEVEL);
 #define WRITE_BLOCK_SIZE_FROM_DT DT_PROP(RRAM, write_block_size)
 #define ERASE_VALUE              0xFF
 
-#if CONFIG_TRUSTED_EXECUTION_NONSECURE && USE_PARTITION_MANAGER
+#if CONFIG_TRUSTED_EXECUTION_NONSECURE
 #include <soc_secure.h>
+#if USE_PARTITION_MANAGER
 #include <pm_config.h>
-#endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE && USE_PARTITION_MANAGER */
+#endif /* USE_PARTITION_MANAGER */
+#endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
 
 #ifdef CONFIG_MULTITHREADING
 static struct k_sem sem_lock;
@@ -297,11 +299,17 @@ static int nrf_rram_read(const struct device *dev, off_t addr, void *data, size_
 	}
 	addr += RRAM_START;
 
-#if CONFIG_TRUSTED_EXECUTION_NONSECURE && USE_PARTITION_MANAGER && PM_APP_ADDRESS
+#if CONFIG_TRUSTED_EXECUTION_NONSECURE
+#if USE_PARTITION_MANAGER && PM_APP_ADDRESS
 	if (addr < PM_APP_ADDRESS) {
 		return soc_secure_mem_read(data, (void *)addr, len);
 	}
+#elif !USE_PARTITION_MANAGER && DT_NODE_EXISTS(DT_NODELABEL(slot0_ns_partition))
+	if ((uintptr_t)addr < DT_REG_ADDR(DT_NODELABEL(slot0_ns_partition))) {
+		return soc_secure_mem_read(data, (void *)addr, len);
+	}
 #endif
+#endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
 
 	memcpy(data, (void *)addr, len);
 


### PR DESCRIPTION
Backport e2cd79452422fa825e901f285abc7f6d91d94393 from #4129.