### PR TITLE
[Backport ncs-v3.4-branch] nrf_wifi: Fix issues with patch download on NRF54H20

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -164,6 +164,25 @@ config NRF_WIFI_PATCHES_EXTERNAL
 	  Select this option to load nRF70 FW patches from an external tooling.
 endchoice
 
+config NRF70_PATCH_DL_CHUNK_SIZE
+	int "nRF70 firmware patch download chunk size (bytes)"
+	# Each chunk maps to a single SPI/QSPI transfer, so it must fit both the
+	# host EasyDMA MAXCNT and any DMA bounce region used by the bus driver.
+	# On the nRF54H the bounce buffer comes from the small 4 KB cpuapp DMA
+	# region that is shared with the console UART and other peripherals, so a
+	# 4 KB chunk cannot find contiguous space there and the download fails;
+	# default to 2048 on that SoC. 4096 elsewhere stays within the 13-bit
+	# nRF91 EasyDMA MAXCNT (8191 bytes).
+	default 2048 if SOC_SERIES_NRF54H
+	default 4096
+	range 256 8192
+	help
+	  Size of each chunk used when downloading the nRF70 firmware patches to
+	  the RPU over SPI/QSPI. Larger chunks load the firmware in fewer bus
+	  transfers, smaller chunks reduce the peak heap usage. The default is
+	  picked per SoC to stay within the bus DMA limits, so only lower this if
+	  your SoC is more constrained than the default already assumes.
+
 config NRF_WIFI_LOW_POWER
 	bool "Low power mode in nRF Wi-Fi chipsets"
 	depends on !NRF70_RADIO_TEST && !NRF70_AP_MODE

--- a/modules/nrf_wifi/os/shim.c
+++ b/modules/nrf_wifi/os/shim.c
@@ -183,10 +183,15 @@ static void zep_shim_qspi_cpy_to(void *priv, unsigned long addr, const void *src
 	struct zep_shim_bus_qspi_priv *qspi_priv = priv;
 	struct qspi_dev *dev;
 	size_t count_aligned = ROUND_UP(count, 4);
+	int ret;
 
 	dev = qspi_priv->qspi_dev;
 
-	dev->write(addr, src, count_aligned);
+	ret = dev->write(addr, src, count_aligned);
+	if (ret) {
+		LOG_ERR("%s: write to 0x%lx (%zu bytes) failed: %d", __func__, addr,
+			count_aligned, ret);
+	}
 }
 
 static void *zep_shim_spinlock_alloc(void)


### PR DESCRIPTION
Backport b1fd0755fc8e18fe887dae9828eb9a6114762a81~2..b1fd0755fc8e18fe887dae9828eb9a6114762a81 from #4198.

manifest-pr-skip