### PR TITLE
[nrf fromtree] drivers: adc: nrfx_saadc: Add support for VDD reference

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -200,6 +200,11 @@ static int reference_set(nrf_saadc_channel_config_t *ch_cfg, enum adc_reference 
 		ch_cfg->reference = NRF_SAADC_REFERENCE_EXTERNAL;
 		break;
 #endif
+#if NRF_SAADC_HAS_REFERENCE_VDD
+	case ADC_REF_VDD_1:
+		ch_cfg->reference = NRF_SAADC_REFERENCE_VDD;
+		break;
+#endif
 	default:
 		LOG_ERR("Selected ADC reference is not valid");
 		return -EINVAL;


### PR DESCRIPTION
Add support for VDD reference in SAADC SHIM.

Upstream PR #: [111384](https://github.com/zephyrproject-rtos/zephyr/pull/111384)

manifest-pr-skip