### PR TITLE
Nordic nrf mramc flash driver update downstream

### DIFF
--- a/drivers/flash/Kconfig.nrf_mramc
+++ b/drivers/flash/Kconfig.nrf_mramc
@@ -38,3 +38,15 @@ config SOC_FLASH_NRF_MRAMC_FLUSH_CACHE
 	help
 	  Enables invalidation of the MRAM cache after write and erase operations to
 	  ensure data read consistency.
+
+config NRF_MRAMC_MAX_RETRIES
+	int "Maximum number of retries for MRAM write/erase operations"
+	default 20
+	range 0 255
+	depends on SOC_FLASH_NRF_MRAMC
+	help
+	  This option sets the maximum number of retry attempts for MRAM
+	  write and erase operations when verification fails. Each retry
+	  attempts to rewrite or re-erase the data to ensure reliability.
+	  Higher values increase reliability but may impact performance
+	  in case of persistent failures.

--- a/drivers/flash/Kconfig.nrf_mramc
+++ b/drivers/flash/Kconfig.nrf_mramc
@@ -7,13 +7,11 @@
 config SOC_FLASH_NRF_MRAMC
 	bool "Nordic Semiconductor flash driver for MRAM using MRAM Controller"
 	default y
-	depends on !BUILD_WITH_TFM
 	depends on DT_HAS_NORDIC_NRF_MRAMC_ENABLED
-	select NRFX_MRAMC
+	imply NRFX_MRAMC if !BUILD_WITH_TFM
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_NO_EXPLICIT_ERASE
-	select SOC_FLASH_NRF_MRAMC_FLUSH_CACHE
 	imply MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	help
 	  Enables Nordic Semiconductor flash driver for MRAMC in direct write mode.
@@ -31,18 +29,10 @@ config NRF_MRAMC_REGION_SIZE_UNIT
 	help
 	  Base unit for the size of MRAMC's region protection.
 
-config SOC_FLASH_NRF_MRAMC_FLUSH_CACHE
-	bool "Invalidate MRAM cache after erase operations"
-	default y
-	depends on SOC_FLASH_NRF_MRAMC
-	help
-	  Enables invalidation of the MRAM cache after write and erase operations to
-	  ensure data read consistency.
-
 config NRF_MRAMC_MAX_RETRIES
 	int "Maximum number of retries for MRAM write/erase operations"
 	default 20
-	range 0 255
+	range 1 255
 	depends on SOC_FLASH_NRF_MRAMC
 	help
 	  This option sets the maximum number of retry attempts for MRAM

--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -17,25 +17,13 @@ LOG_MODULE_REGISTER(flash_nrf_mramc, CONFIG_FLASH_LOG_LEVEL);
 
 #define DT_DRV_COMPAT nordic_nrf_mramc
 
-#define _ADD_SIZE(node_id) + DT_REG_SIZE(node_id)
-#define _WBS(node_id)	   DT_PROP(node_id, write_block_size),
-#define _EBS(node_id)	   DT_PROP(node_id, erase_block_size),
+#define MRAM_NODE         DT_NODELABEL(cpuapp_mram)
+#define MRAM_SIZE         DT_REG_SIZE(MRAM_NODE)
+#define WRITE_BLOCK_SIZE  DT_PROP(MRAM_NODE, write_block_size)
+#define ERASE_BLOCK_SIZE  DT_PROP(MRAM_NODE, erase_block_size)
 
-#define MRAM_SIZE   (0 DT_INST_FOREACH_CHILD_STATUS_OKAY(0, _ADD_SIZE))
-#define ERASE_VALUE (uint8_t)NRFY_MRAMC_WORD_AFTER_ERASED
-
-/* Use DT_FOREACH_CHILD_STATUS_OKAY of mramc with _FIRST() helper
- * macro to get the write block size and erase block size from
- * the first child node.
- */
-#define WBS_LIST  DT_INST_FOREACH_CHILD_STATUS_OKAY(0, _WBS)
-#define EBS_LIST  DT_INST_FOREACH_CHILD_STATUS_OKAY(0, _EBS)
-
-#define _FIRST_HELPER(first, ...)  first
-#define _FIRST(...)  _FIRST_HELPER(__VA_ARGS__)
-
-#define WRITE_BLOCK_SIZE  _FIRST(WBS_LIST)
-#define ERASE_BLOCK_SIZE  _FIRST(EBS_LIST)
+#define ERASE_VALUE                NRFY_MRAMC_WORD_AFTER_ERASED
+#define MRAMC_MIN_BYTES_DATA_WIDTH NRFY_MRAMC_BYTES_IN_WORD
 
 BUILD_ASSERT((ERASE_BLOCK_SIZE % WRITE_BLOCK_SIZE) == 0,
 		 "erase-block-size expected to be a multiple of write-block-size");
@@ -59,12 +47,49 @@ static bool validate_action(uint32_t addr, size_t len, bool must_align)
 		return false;
 	}
 
-	if (must_align && !(nrfx_is_word_aligned((void const *)addr))) {
-		LOG_ERR("Address %x is not word aligned", addr);
+	if (must_align && (!(nrfx_is_word_aligned((void const *)addr)) ||
+		 ((len % MRAMC_MIN_BYTES_DATA_WIDTH) != 0))) {
+		LOG_ERR("Address %x is not word aligned or data length is not multiple of %u",
+			addr, MRAMC_MIN_BYTES_DATA_WIDTH);
 		return false;
 	}
 
 	return true;
+}
+
+/**
+ * @brief Verifies the data written to MRAM.
+ *
+ * @param[in] addr     Address of mram memory.
+ * @param[in] len      Number of bytes for the intended operation.
+ * @param[in] is_erase Whether is verifying erase operation.
+ *
+ * @return true if the address and length are valid, false otherwise.
+ */
+static int nrf_mramc_verify_data(off_t offset, const void *data, size_t size, bool is_erase)
+{
+	uint32_t addr = NRFX_MRAMC_MAP_TO_ADDR(offset);
+	uint32_t num_words = size / MRAMC_MIN_BYTES_DATA_WIDTH;
+
+	const uint32_t *mram = (const uint32_t *)addr;
+	const uint32_t *buf  = (const uint32_t *)data;
+
+	/* Compare and verify written data */
+	for (size_t i = 0; i < num_words; i++) {
+		uint32_t w = mram[i];
+
+		if (is_erase) {
+			if (w != ERASE_VALUE) {
+				return -EIO;
+			}
+		} else {
+			if (w != buf[i]) {
+				return -EIO;
+			}
+		}
+	}
+
+	return 0;
 }
 
 static int nrf_mramc_read(const struct device *dev, off_t offset, void *data, size_t len)
@@ -91,10 +116,11 @@ static int nrf_mramc_read(const struct device *dev, off_t offset, void *data, si
 }
 
 static int nrf_mramc_write(const struct device *dev, off_t offset,
-			 const void *data, size_t len)
+			 const void *data, size_t size)
 {
 	ARG_UNUSED(dev);
 	uint32_t addr = NRFX_MRAMC_MAP_TO_ADDR(offset);
+	uint8_t  retries = CONFIG_NRF_MRAMC_MAX_RETRIES;
 
 	if (data == NULL) {
 		LOG_ERR("Data pointer is NULL");
@@ -102,24 +128,34 @@ static int nrf_mramc_write(const struct device *dev, off_t offset,
 	}
 
 	/* Validate addr and length in the range */
-	if (!validate_action(addr, len, true)) {
+	if (!validate_action(addr, size, true)) {
 		return -EINVAL;
 	}
 
-	LOG_DBG("write: %x:%zu", addr, len);
+	LOG_DBG("write: %x:%zu", addr, size);
 
-	/* Words write function takes second argument as number of write blocks
-	 * and not number of bytes
-	 */
-	nrfx_mramc_words_write(addr, data, len / WRITE_BLOCK_SIZE);
+	while (retries--) {
+		/* Words write function takes second argument as number of write blocks
+		 * and not number of bytes
+		 */
+		nrfx_mramc_words_write(addr, data, size / MRAMC_MIN_BYTES_DATA_WIDTH);
 
-	return 0;
+		if (!nrf_mramc_verify_data(offset, data, size, false)) {
+			return 0;
+		}
+		LOG_ERR("MRAM write verification failed at address 0x%x, retrying... (%u retries "
+			"left)",
+			addr, retries);
+	}
+
+	return -EIO;
 }
 
 static int nrf_mramc_erase(const struct device *dev, off_t offset, size_t size)
 {
 	ARG_UNUSED(dev);
 	uint32_t addr = NRFX_MRAMC_MAP_TO_ADDR(offset);
+	uint8_t  retries = CONFIG_NRF_MRAMC_MAX_RETRIES;
 
 	/* Validate addr and length in the range */
 	if (size == 0) {
@@ -133,14 +169,23 @@ static int nrf_mramc_erase(const struct device *dev, off_t offset, size_t size)
 
 	LOG_DBG("erase: %p:%zu", (void *)addr, size);
 
-	/* Erase function takes second argument as number of write blocks
-	 * and not number of bytes
-	 */
-	nrfx_mramc_area_erase(addr, size / WRITE_BLOCK_SIZE);
+	while (retries--) {
+		/* Erase function takes second argument as number of 32-bit words
+		 * and not number of bytes
+		 */
+		nrfx_mramc_erase(addr, size / MRAMC_MIN_BYTES_DATA_WIDTH);
+
 #if defined(CONFIG_SOC_FLASH_NRF_MRAMC_FLUSH_CACHE)
-	sys_cache_instr_invd_all();
+	    sys_cache_instr_invd_all();
 #endif
-	return 0;
+		if (!nrf_mramc_verify_data(offset, NULL, size, true)) {
+			return 0;
+		}
+		LOG_ERR("MRAM Erase verification failed at address 0x%x, retrying... (%u retries "
+			"left)",  addr, retries);
+	}
+
+	return -EIO;
 }
 
 static int nrf_mramc_get_size(const struct device *dev, uint64_t *size)
@@ -156,7 +201,7 @@ static const struct flash_parameters *nrf_mramc_get_parameters(const struct devi
 
 	static const struct flash_parameters parameters = {
 		.write_block_size = WRITE_BLOCK_SIZE,
-		.erase_value = ERASE_VALUE,
+		.erase_value = (uint8_t) ERASE_VALUE,
 		.caps = {
 			.no_explicit_erase = true,
 		},

--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -8,49 +8,77 @@
 
 #include <zephyr/drivers/flash.h>
 #include <zephyr/logging/log.h>
+
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+#include "tfm_ioctl_core_api.h"
+#else
 #include <nrfx_mramc.h>
-#if defined(CONFIG_SOC_FLASH_NRF_MRAMC_FLUSH_CACHE)
-#include <zephyr/cache.h>
 #endif
 
 LOG_MODULE_REGISTER(flash_nrf_mramc, CONFIG_FLASH_LOG_LEVEL);
 
 #define DT_DRV_COMPAT nordic_nrf_mramc
 
-#define MRAM_NODE         DT_NODELABEL(cpuapp_mram)
-#define MRAM_SIZE         DT_REG_SIZE(MRAM_NODE)
+#define MRAM_NODE		  DT_NODELABEL(cpuapp_mram)
+#define MRAM_BASE		 DT_REG_ADDR(MRAM_NODE)
+#define MRAM_SIZE		  DT_REG_SIZE(MRAM_NODE)
+
+BUILD_ASSERT(MRAM_BASE <= UINT32_MAX, "MRAM_BASE is not in size of uint32_t");
+BUILD_ASSERT(MRAM_SIZE <= UINT32_MAX, "MRAM_SIZE is not in size of uint32_t");
+
 #define WRITE_BLOCK_SIZE  DT_PROP(MRAM_NODE, write_block_size)
 #define ERASE_BLOCK_SIZE  DT_PROP(MRAM_NODE, erase_block_size)
 
-#define ERASE_VALUE                NRFY_MRAMC_WORD_AFTER_ERASED
-#define MRAMC_MIN_BYTES_DATA_WIDTH NRFY_MRAMC_BYTES_IN_WORD
+#define ERASE_VALUE				   0xFFFFFFFF
+#define MRAM_WORD_SIZE	16
+#define MRAMC_CONFIG_WEN_NORMAL	1
+#define MRAMC_CONFIG_WEN_DISABLE   0
 
+#define MAP_TO_ADDR(offset) (MRAM_BASE + offset)
+
+BUILD_ASSERT((WRITE_BLOCK_SIZE % MRAM_WORD_SIZE) == 0,
+		 "write-block-size expected to be a multiple of MRAM_WORD_SIZE");
 BUILD_ASSERT((ERASE_BLOCK_SIZE % WRITE_BLOCK_SIZE) == 0,
 		 "erase-block-size expected to be a multiple of write-block-size");
 
+struct k_mutex nrf_mramc_mutex;
+
 /**
- * @param[in] addr       Address of mram memory.
- * @param[in] len        Number of bytes for the intended operation.
+ * @param[in] addr		 Address of mram memory.
+ * @param[in] len		 Number of bytes for the intended operation.
  * @param[in] must_align Require MRAM word alignment, if applicable.
  *
  * @return true if the address and length are valid, false otherwise.
  */
 static bool validate_action(uint32_t addr, size_t len, bool must_align)
 {
-	if (!nrfx_mramc_valid_address_check(addr, true)) {
+	bool valid = true;
+
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	valid = (addr >= MRAM_BASE && addr < (MRAM_BASE + MRAM_SIZE));
+#else
+	valid = nrfx_mramc_valid_address_check(addr, true);
+#endif
+	if (!valid) {
 		LOG_ERR("Invalid address: %x", addr);
 		return false;
 	}
 
-	if (!nrfx_mramc_fits_memory_check(addr, true, len)) {
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	valid = (((addr - (uint32_t)MRAM_BASE) < MRAM_SIZE) &&
+		(len <= ((uint32_t)MRAM_BASE + MRAM_SIZE - addr)));
+#else
+	valid = nrfx_mramc_fits_memory_check(addr, true, len);
+#endif
+	if (!valid) {
 		LOG_ERR("Address %x with length %zu exceeds MRAM size", addr, len);
 		return false;
 	}
 
-	if (must_align && (!(nrfx_is_word_aligned((void const *)addr)) ||
-		 ((len % MRAMC_MIN_BYTES_DATA_WIDTH) != 0))) {
-		LOG_ERR("Address %x is not word aligned or data length is not multiple of %u",
-			addr, MRAMC_MIN_BYTES_DATA_WIDTH);
+	if (must_align && (((addr % MRAM_WORD_SIZE) != 0) ||
+		 ((len % MRAM_WORD_SIZE) != 0))) {
+		LOG_ERR("Address %x is not block aligned or data length is not multiple of %u",
+			addr, MRAM_WORD_SIZE);
 		return false;
 	}
 
@@ -60,42 +88,72 @@ static bool validate_action(uint32_t addr, size_t len, bool must_align)
 /**
  * @brief Verifies the data written to MRAM.
  *
- * @param[in] addr     Address of mram memory.
- * @param[in] len      Number of bytes for the intended operation.
+ * @param[in] offset   Offset of mram memory from base address.
+ * @param[in] len	   Number of bytes for the intended operation.
  * @param[in] is_erase Whether is verifying erase operation.
  *
  * @return true if the address and length are valid, false otherwise.
  */
 static int nrf_mramc_verify_data(off_t offset, const void *data, size_t size, bool is_erase)
 {
-	uint32_t addr = NRFX_MRAMC_MAP_TO_ADDR(offset);
-	uint32_t num_words = size / MRAMC_MIN_BYTES_DATA_WIDTH;
+	uint32_t *mram_start = (uint32_t *) MAP_TO_ADDR(offset);
+	uint32_t *mram_end = mram_start + size / sizeof(uint32_t);
 
-	const uint32_t *mram = (const uint32_t *)addr;
-	const uint32_t *buf  = (const uint32_t *)data;
-
-	/* Compare and verify written data */
-	for (size_t i = 0; i < num_words; i++) {
-		uint32_t w = mram[i];
-
-		if (is_erase) {
-			if (w != ERASE_VALUE) {
-				return -EIO;
-			}
-		} else {
-			if (w != buf[i]) {
+	if (is_erase) {
+		while (mram_start < mram_end) {
+			if (*mram_start++ != ERASE_VALUE) {
 				return -EIO;
 			}
 		}
+		return 0;
+	}
+
+	/* Use word comparison when the source buffer is word-aligned. */
+	if (((uintptr_t)data % sizeof(uint32_t)) == 0) {
+		const uint32_t *buf = (const uint32_t *)data;
+
+		while (mram_start < mram_end) {
+			if (*mram_start++ != *buf++) {
+				return -EIO;
+			}
+		}
+		return 0;
+	}
+
+	/* Otherwise, fall back to byte comparison to avoid unaligned
+	 * uint32_t accesses from data.
+	 */
+	if (memcmp((const void *)mram_start, data, size) != 0) {
+		return -EIO;
+	}
+	return 0;
+}
+
+/**
+ * @brief Setting the write enable mode of MRAM controller.
+ *
+ * @param[in] mode  Write enable mode to set, either normal(1) or disable(0).
+ *
+ * @return true if mode change is successful, false otherwise.
+ */
+static int nrf_mramc_set_wen(uint32_t mode)
+{
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	return tfm_platform_mramc_set_wen(mode);
+#else
+	nrfx_mramc_config_write_mode_set(mode);
+
+	while (!nrfx_mramc_ready_check()) {
 	}
 
 	return 0;
+#endif
 }
 
 static int nrf_mramc_read(const struct device *dev, off_t offset, void *data, size_t len)
 {
 	ARG_UNUSED(dev);
-	uint32_t addr = NRFX_MRAMC_MAP_TO_ADDR(offset);
+	uint32_t addr = MAP_TO_ADDR(offset);
 
 	if (data == NULL) {
 		LOG_ERR("Data pointer is NULL");
@@ -111,16 +169,96 @@ static int nrf_mramc_read(const struct device *dev, off_t offset, void *data, si
 
 	/* Buffer read number of bytes and store in data pointer.
 	 */
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	memcpy(data, (void *)addr, len);
+#else
 	nrfx_mramc_buffer_read(data, addr, len);
+#endif
 	return 0;
+}
+
+/**
+ * @brief Writes a word with MRAM_WORD_SIZE to MRAM and verifies the written data.
+ *
+ * @param addr  Destination address. Must be aligned to MRAM_WORD_SIZE (16 bytes).
+ * @param data  Pointer to the source data buffer.
+ *
+ * @retval 0	   Write succeeded.
+ * @retval -EIO	Write failed after all retries.
+ */
+static int nrf_mram_write_and_verify_word(uint32_t addr, void *data)
+{
+	uint8_t retries = CONFIG_NRF_MRAMC_MAX_RETRIES;
+
+	while (retries--) {
+		/* Check if data address is aligned to 4 bytes */
+		if (((uintptr_t)data % 4) == 0) {
+			uint32_t *mram_start = (uint32_t *)addr;
+			uint32_t *mram_end = mram_start + sizeof(uint32_t);
+			uint32_t *data_ptr = (uint32_t *)data;
+
+			/* Aligned: use fast uint32_t copies */
+			while (mram_start < mram_end) {
+				*mram_start++ = *data_ptr++;
+			}
+		} else {
+			/* Not aligned: use memcpy */
+			memcpy((void *)addr, data, MRAM_WORD_SIZE);
+		}
+
+		if (!nrf_mramc_verify_data(addr, data, MRAM_WORD_SIZE, false)) {
+			return 0;
+		}
+		LOG_ERR("MRAM write verification failed at address 0x%x, retrying... (%u retries "
+			"left)",
+			addr, retries);
+	}
+
+	LOG_ERR("MRAM write failed at address 0x%x, after %u retries ",
+		addr, retries);
+	return -EIO;
+}
+
+/**
+ * @brief Erase a word with MRAM_WORD_SIZE to MRAM and verifies the written data.
+ *
+ * @param addr		Destination address. Must be aligned to MRAM_WORD_SIZE (16 bytes).
+ *
+ * @retval 0		Erase succeeded and no corruption was detected.
+ * @retval -EIO		Erase failed after all retries.
+ */
+static int nrf_mram_erase_and_verify_word(uint32_t addr)
+{
+	uint8_t retries = CONFIG_NRF_MRAMC_MAX_RETRIES;
+
+	while (retries--) {
+		uint32_t *mram_start = (uint32_t *)addr;
+		uint32_t *mram_end = mram_start + sizeof(uint32_t);
+
+		/* Check if data address is aligned to 4 bytes */
+		while (mram_start < mram_end) {
+			*mram_start++ = 0xFFFFFFFFu;
+		}
+
+		if (!nrf_mramc_verify_data(addr, NULL, MRAM_WORD_SIZE, true)) {
+			return 0;
+		}
+		LOG_ERR("MRAM erase verification failed at address 0x%x, retrying... (%u retries "
+			"left)",
+			addr, retries);
+	}
+
+	LOG_ERR("MRAM erase failed at address 0x%x, after %u retries ",
+		addr, retries);
+	return -EIO;
 }
 
 static int nrf_mramc_write(const struct device *dev, off_t offset,
 			 const void *data, size_t size)
 {
 	ARG_UNUSED(dev);
-	uint32_t addr = NRFX_MRAMC_MAP_TO_ADDR(offset);
-	uint8_t  retries = CONFIG_NRF_MRAMC_MAX_RETRIES;
+	uint32_t addr = MAP_TO_ADDR(offset);
+	uint32_t ret = 0;
 
 	if (data == NULL) {
 		LOG_ERR("Data pointer is NULL");
@@ -134,28 +272,29 @@ static int nrf_mramc_write(const struct device *dev, off_t offset,
 
 	LOG_DBG("write: %x:%zu", addr, size);
 
-	while (retries--) {
-		/* Words write function takes second argument as number of write blocks
-		 * and not number of bytes
-		 */
-		nrfx_mramc_words_write(addr, data, size / MRAMC_MIN_BYTES_DATA_WIDTH);
+	k_mutex_lock(&nrf_mramc_mutex, K_FOREVER);
 
-		if (!nrf_mramc_verify_data(offset, data, size, false)) {
-			return 0;
+	for (uint32_t i = 0; i < size; i += MRAM_WORD_SIZE) {
+		/* Write full 16 bytes word for N iterations */
+		nrf_mramc_set_wen(MRAMC_CONFIG_WEN_NORMAL);
+		ret = nrf_mram_write_and_verify_word(addr + i, (void *)((uintptr_t)data + i));
+		nrf_mramc_set_wen(MRAMC_CONFIG_WEN_DISABLE);
+
+		if (ret) {
+			k_mutex_unlock(&nrf_mramc_mutex);
+			return ret;
 		}
-		LOG_ERR("MRAM write verification failed at address 0x%x, retrying... (%u retries "
-			"left)",
-			addr, retries);
 	}
 
-	return -EIO;
+	k_mutex_unlock(&nrf_mramc_mutex);
+	return 0;
 }
 
 static int nrf_mramc_erase(const struct device *dev, off_t offset, size_t size)
 {
 	ARG_UNUSED(dev);
-	uint32_t addr = NRFX_MRAMC_MAP_TO_ADDR(offset);
-	uint8_t  retries = CONFIG_NRF_MRAMC_MAX_RETRIES;
+	uint32_t addr = MAP_TO_ADDR(offset);
+	uint32_t ret = 0;
 
 	/* Validate addr and length in the range */
 	if (size == 0) {
@@ -169,29 +308,32 @@ static int nrf_mramc_erase(const struct device *dev, off_t offset, size_t size)
 
 	LOG_DBG("erase: %p:%zu", (void *)addr, size);
 
-	while (retries--) {
-		/* Erase function takes second argument as number of 32-bit words
-		 * and not number of bytes
-		 */
-		nrfx_mramc_erase(addr, size / MRAMC_MIN_BYTES_DATA_WIDTH);
+	k_mutex_lock(&nrf_mramc_mutex, K_FOREVER);
 
-#if defined(CONFIG_SOC_FLASH_NRF_MRAMC_FLUSH_CACHE)
-	    sys_cache_instr_invd_all();
-#endif
-		if (!nrf_mramc_verify_data(offset, NULL, size, true)) {
-			return 0;
+	for (uint32_t i = 0; i < size; i += MRAM_WORD_SIZE) {
+		/* Erase full 16 bytes word for N iterations */
+		nrf_mramc_set_wen(MRAMC_CONFIG_WEN_NORMAL);
+		ret = nrf_mram_erase_and_verify_word(addr + i);
+		nrf_mramc_set_wen(MRAMC_CONFIG_WEN_DISABLE);
+
+		if (ret) {
+			k_mutex_unlock(&nrf_mramc_mutex);
+			return ret;
 		}
-		LOG_ERR("MRAM Erase verification failed at address 0x%x, retrying... (%u retries "
-			"left)",  addr, retries);
 	}
 
-	return -EIO;
+	k_mutex_unlock(&nrf_mramc_mutex);
+	return 0;
 }
 
 static int nrf_mramc_get_size(const struct device *dev, uint64_t *size)
 {
 	ARG_UNUSED(dev);
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	*size = MRAM_SIZE;
+#else
 	*size = nrfx_mramc_memory_size_get();
+#endif
 	return 0;
 }
 
@@ -230,8 +372,23 @@ static int mramc_sys_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
+	int ret = 0;
+
+	k_mutex_init(&nrf_mramc_mutex);
+
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	/* Initialization of MRAMC driver via secure processing environment */
+	enum tfm_platform_err_t status = tfm_platform_mramc_init();
+
+	if (status != TFM_PLATFORM_ERR_SUCCESS) {
+		LOG_ERR("Failed to initialize MRAMC via TF-M service: %d", status);
+		ret = -EIO;
+	}
+#else
 	nrfx_mramc_config_t config = NRFX_MRAMC_DEFAULT_CONFIG();
-	int ret = nrfx_mramc_init(&config, NULL);
+
+	ret = nrfx_mramc_init(&config, NULL);
+#endif
 
 	if (ret != 0) {
 		LOG_ERR("Failed to initialize MRAMC: %d", ret);

--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include <zephyr/drivers/flash.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)

--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -42,7 +42,16 @@ BUILD_ASSERT((WRITE_BLOCK_SIZE % MRAM_WORD_SIZE) == 0,
 BUILD_ASSERT((ERASE_BLOCK_SIZE % WRITE_BLOCK_SIZE) == 0,
 		 "erase-block-size expected to be a multiple of write-block-size");
 
-struct k_mutex nrf_mramc_mutex;
+#ifdef CONFIG_MULTITHREADING
+static struct k_mutex nrf_mramc_mutex;
+#define SYNC_INIT()   k_mutex_init(&nrf_mramc_mutex)
+#define SYNC_LOCK()   k_mutex_lock(&nrf_mramc_mutex, K_FOREVER)
+#define SYNC_UNLOCK() k_mutex_unlock(&nrf_mramc_mutex)
+#else
+#define SYNC_INIT()
+#define SYNC_LOCK()
+#define SYNC_UNLOCK()
+#endif /* CONFIG_MULTITHREADING */
 
 /**
  * @param[in] addr		 Address of mram memory.
@@ -273,7 +282,7 @@ static int nrf_mramc_write(const struct device *dev, off_t offset,
 
 	LOG_DBG("write: %x:%zu", addr, size);
 
-	k_mutex_lock(&nrf_mramc_mutex, K_FOREVER);
+	SYNC_LOCK();
 
 	for (uint32_t i = 0; i < size; i += MRAM_WORD_SIZE) {
 		/* Write full 16 bytes word for N iterations */
@@ -282,12 +291,12 @@ static int nrf_mramc_write(const struct device *dev, off_t offset,
 		nrf_mramc_set_wen(MRAMC_CONFIG_WEN_DISABLE);
 
 		if (ret) {
-			k_mutex_unlock(&nrf_mramc_mutex);
+			SYNC_UNLOCK();
 			return ret;
 		}
 	}
 
-	k_mutex_unlock(&nrf_mramc_mutex);
+	SYNC_UNLOCK();
 	return 0;
 }
 
@@ -309,7 +318,7 @@ static int nrf_mramc_erase(const struct device *dev, off_t offset, size_t size)
 
 	LOG_DBG("erase: %p:%zu", (void *)addr, size);
 
-	k_mutex_lock(&nrf_mramc_mutex, K_FOREVER);
+	SYNC_LOCK();
 
 	for (uint32_t i = 0; i < size; i += MRAM_WORD_SIZE) {
 		/* Erase full 16 bytes word for N iterations */
@@ -318,12 +327,12 @@ static int nrf_mramc_erase(const struct device *dev, off_t offset, size_t size)
 		nrf_mramc_set_wen(MRAMC_CONFIG_WEN_DISABLE);
 
 		if (ret) {
-			k_mutex_unlock(&nrf_mramc_mutex);
+			SYNC_UNLOCK();
 			return ret;
 		}
 	}
 
-	k_mutex_unlock(&nrf_mramc_mutex);
+	SYNC_UNLOCK();
 	return 0;
 }
 
@@ -375,7 +384,7 @@ static int mramc_sys_init(const struct device *dev)
 
 	int ret = 0;
 
-	k_mutex_init(&nrf_mramc_mutex);
+	SYNC_INIT();
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	/* Initialization of MRAMC driver via secure processing environment */

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -1009,7 +1009,7 @@
 				reg = <0 DT_SIZE_K(4076)>;
 				ranges = <0x0 0 DT_SIZE_K(4076)>;
 				erase-block-size = <4096>;
-				write-block-size = <4>;
+				write-block-size = <16>;
 				#address-cells = <1>;
 				#size-cells = <1>;
 			};

--- a/soc/nordic/CMakeLists.txt
+++ b/soc/nordic/CMakeLists.txt
@@ -38,11 +38,18 @@ endif()
 if(CONFIG_BUILD_WITH_TFM)
   set_property(TARGET zephyr_property_target
     APPEND PROPERTY TFM_CMAKE_OPTIONS -DHAL_NORDIC_PATH=${ZEPHYR_HAL_NORDIC_MODULE_DIR}
-    )
+  )
+
+  if(CONFIG_SOC_NRF7120_TFM_MRAMC_SERVICE)
+    set(nrf_mramc_service ON)
+  else()
+    set(nrf_mramc_service OFF)
+  endif()
 
   set_property(TARGET zephyr_property_target
     APPEND PROPERTY TFM_CMAKE_OPTIONS -DNRF_NS_STORAGE=${CONFIG_TFM_NRF_NS_STORAGE}
-    )
+    APPEND PROPERTY TFM_CMAKE_OPTIONS -DNRF_MRAMC_SERVICE=${nrf_mramc_service}
+  )
 endif()
 
 add_subdirectory(${SOC_SERIES})

--- a/soc/nordic/nrf71/Kconfig
+++ b/soc/nordic/nrf71/Kconfig
@@ -41,4 +41,15 @@ config SOC_NRF71_WIFI_BOOT
 	  disabled, the Wi-Fi core must be started by the application before it can be
 	  used.
 
+config SOC_NRF7120_TFM_MRAMC_SERVICE
+	bool "TF-M MRAMC service"
+	default y
+	depends on SOC_NRF7120
+	depends on SOC_FLASH_NRF_MRAMC
+	depends on BUILD_WITH_TFM
+	help
+	  Provide a MRAMC service for the nRF7120 SoC.
+	  This service allows the non-secure application to request
+	  the system to configure MRAMC using a secure service call.
+
 endif # SOC_SERIES_NRF71


### PR DESCRIPTION
Cherry-pick mramc flash update with nrf_mramc flash driver write verification and tf-m support to access mramc driver.

This is needed to merge along with: https://github.com/nrfconnect/sdk-nrf/pull/29721