### PR TITLE
nordic: nrf7120: initial support for tfm mcuboot ncs downstream

### DIFF
--- a/boards/nordic/nrf7120dk/Kconfig.defconfig
+++ b/boards/nordic/nrf7120dk/Kconfig.defconfig
@@ -19,15 +19,4 @@ config BOARD_NRF7120DK
 config HAS_BT_CTLR
 	default BT
 
-# By default, if we build for a Non-Secure version of the board,
-# enable building with TF-M as the Secure Execution Environment.
-config BUILD_WITH_TFM
-	default y
-
-# By default, if we build with TF-M, instruct build system to
-# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-config TFM_FLASH_MERGED_BINARY
-	default y
-	depends on BUILD_WITH_TFM
-
 endif # BOARD_NRF7120DK_NRF7120_CPUAPP_NS

--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -66,8 +66,6 @@
 	status = "okay";
 	firmware-lmacinitpc = <&wifi_lmac_rom>;
 	firmware-umacinitpc = <&wifi_umac_rom>;
-	firmware-lmacrompatchaddr = <&wifi_lmac_patch_partition>;
-	firmware-umacrompatchaddr = <&wifi_umac_patch_partition>;
 	ipcconfig-commandmbox = <&ipc_shm_cpuapp_cpuuma_0>;
 	ipcconfig-eventmbox = <&ipc_shm_cpuuma_cpuapp_0>;
 	ipcconfig-sparembox = <&ipc_shm_sparembox>;

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -45,28 +45,28 @@
 			ranges = <0x0 0x0 DT_SIZE_K(416)>;
 		};
 
-		sram01_ns: sram0_ns@60000 {
+		sram01_ns: sram0_ns@68000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
 			/* Non-Secure RAM */
-			reg = <0x60000 DT_SIZE_K(256)>; /* 0x2008_0000 */
-			ranges = <0x0 0x60000 DT_SIZE_K(256)>;
+			reg = <0x68000 DT_SIZE_K(256)>; /* 0x2008_0000 */
+			ranges = <0x0 0x68000 DT_SIZE_K(256)>;
 		};
 
-		sram02_ns: sram0_ns@a0000 {
+		sram02_ns: sram0_ns@a8000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
 			/* Non-Secure RAM */
-			reg = <0xa0000 DT_SIZE_K(128)>; /* 0x200C_0000 */
-			ranges = <0x0 0xa0000 DT_SIZE_K(128)>;
+			reg = <0xa8000 DT_SIZE_K(128)>; /* 0x200C_0000 */
+			ranges = <0x0 0xa8000 DT_SIZE_K(128)>;
 		};
 
-		sram03_ns: sram0_ns@c0000 {
+		sram03_ns: sram0_ns@c8000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
 			/* Non-Secure RAM */
-			reg = <0xc0000 DT_SIZE_K(120)>; /* 0x200E_0000 */
-			ranges = <0x0 0xc0000 DT_SIZE_K(120)>;
+			reg = <0xc8000 DT_SIZE_K(120)>; /* 0x200E_0000 */
+			ranges = <0x0 0xc8000 DT_SIZE_K(120)>;
 		};
 	};
 };

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -8,11 +8,13 @@
 
 /*
  * Default SRAM planning when building for nRF7120 with ARM TrustZone-M support
- * - Lowest 128 kB in RAM00 allocated to Secure RAM (sram0_s).
- * - Upper 384 kB in RAM00 allocated to Non-Secure RAM (sram00_ns).
- * - 256 kB SRAM in RAM01 allocated to Non-Secure RAM (sram01_ns).
- * - 128 kB SRAM in RAM02 allocated to Non-Secure RAM (sram02_ns).
- * - 120 kB SRAM in RAM03 allocated to Non-Secure RAM (sram03_ns).
+ * Lowest 96 kB allocated to Secure RAM (sram0_s).
+ *   - 96 kB SRAM in RAM00 allocated to Secure RAM      (sram00_s).
+ * Upper 920 kB allocated to Non-Secure RAM (sram0_ns).
+ *   - 416 kB SRAM in RAM00 allocated to Non-Secure RAM (sram00_ns).
+ *   - 256 kB SRAM in RAM01 allocated to Non-Secure RAM (sram01_ns).
+ *   - 128 kB SRAM in RAM02 allocated to Non-Secure RAM (sram02_ns).
+ *   - 120 kB SRAM in RAM03 allocated to Non-Secure RAM (sram03_ns).
  *
  * cpuapp_sram has 1016 kB of volatile memory (SRAM).
  * This static layout needs to be the same with the upstream TF-M layout in the
@@ -24,23 +26,23 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Secure RAM */
-		reg = <0x0 DT_SIZE_K(128)>; /* 0x2000_0000 */
-		ranges = <0x0 0x0 DT_SIZE_K(128)>;
+		reg = <0x0 DT_SIZE_K(96)>; /* 0x2000_0000 */
+		ranges = <0x0 0x0 DT_SIZE_K(96)>;
 	};
 
-	sram0_ns: sram@20000 {
+	sram0_ns: sram@18000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		/* Non-Secure RAM */
-		reg = <0x20000 DT_SIZE_K(888)>; /* 0x2002_0000 */
-		ranges = <0x0 0x20000 DT_SIZE_K(888)>;
+		reg = <0x18000 DT_SIZE_K(920)>; /* 0x2001_8000 */
+		ranges = <0x0 0x18000 DT_SIZE_K(920)>;
 
 		sram00_ns: sram0_ns@0 {
 			#address-cells = <1>;
 			#size-cells = <1>;
 			/* Non-Secure RAM */
-			reg = <0x0 DT_SIZE_K(384)>; /* 0x2002_0000 */
-			ranges = <0x0 0x0 DT_SIZE_K(384)>;
+			reg = <0x0 DT_SIZE_K(416)>; /* 0x2001_8000 */
+			ranges = <0x0 0x0 DT_SIZE_K(416)>;
 		};
 
 		sram01_ns: sram0_ns@60000 {

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -74,13 +74,13 @@
 	 * Default NVM layout on NRF7120 Application MCU without BL2:
 	 * This layout matches (by necessity) that in the TF-M repository:
 	 *
-	 * 0x0000_0000 Secure image primary (512 KB)
-	 * 0x0008_0000 Protected Storage Area (16 KB)
-	 * 0x0008_4000 Internal Trusted Storage Area (16 KB)
-	 * 0x0008_8000 OTP / NV counters area (8 KB)
-	 * 0x0008_A000 Non-secure image primary (844 KB)
-	 * 0x0015_D000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
-	 *             otherwise unused (32 KB)
+	 * 0x0000_0000 Secure image primary (192 KB)
+	 * 0x0003_0000 Protected Storage Area (16 KB)
+	 * 0x0003_4000 Internal Trusted Storage Area (16 KB)
+	 * 0x0003_8000 OTP / NV counters area (8 KB)
+	 * 0x0003_A000 Non-secure image primary (3780 KB)
+	 * 0x003E_B000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+	 *             otherwise unused (64 KB)
 	 */
 	partitions {
 		#address-cells = <1>;
@@ -95,55 +95,37 @@
 		slot0_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
-			reg = <0x0000000 DT_SIZE_K(512)>;
+			reg = <0x0000000 DT_SIZE_K(192)>;
 		};
 
-		tfm_ps_partition: partition@80000 {
+		tfm_ps_partition: partition@30000 {
 			compatible = "zephyr,mapped-partition";
 			label = "tfm-ps";
-			reg = <0x00080000 DT_SIZE_K(16)>;
+			reg = <0x00030000 DT_SIZE_K(16)>;
 		};
 
-		tfm_its_partition: partition@84000 {
+		tfm_its_partition: partition@34000 {
 			compatible = "zephyr,mapped-partition";
 			label = "tfm-its";
-			reg = <0x00084000 DT_SIZE_K(16)>;
+			reg = <0x00034000 DT_SIZE_K(16)>;
 		};
 
-		tfm_otp_partition: partition@88000 {
+		tfm_otp_partition: partition@38000 {
 			compatible = "zephyr,mapped-partition";
 			label = "tfm-otp";
-			reg = <0x00088000 DT_SIZE_K(8)>;
+			reg = <0x00038000 DT_SIZE_K(8)>;
 		};
 
-		slot0_ns_partition: partition@8a000 {
+		slot0_ns_partition: partition@3a000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0-nonsecure";
-			reg = <0x0008a000 DT_SIZE_K(844)>;
+			reg = <0x0003a000 DT_SIZE_K(3780)>;
 		};
 
-		storage_partition: partition@15d000 {
+		storage_partition: partition@3eb000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x00015d000 DT_SIZE_K(32)>;
-		};
-
-		/*
-		 * Reserved for Wi-Fi LMAC ROM patch.
-		 * Temporary FPGA/bring-up placement.
-		 */
-		wifi_lmac_patch_partition: partition@2e0000 {
-			compatible = "zephyr,mapped-partition";
-			reg = <0x002e0000 DT_SIZE_K(4)>;
-		};
-
-		/*
-		 * Reserved for Wi-Fi UMAC ROM patch.
-		 * Temporary FPGA/bring-up placement.
-		 */
-		wifi_umac_patch_partition: partition@2f0000 {
-			compatible = "zephyr,mapped-partition";
-			reg = <0x002f0000 DT_SIZE_K(4)>;
+			reg = <0x0003eb000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/dts/vendor/nordic/nrf7120_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_partition.dtsi
@@ -31,24 +31,6 @@
 			reg = <0x00178000 DT_SIZE_K(1440)>;
 		};
 
-		/*
-		 * Reserved for Wi-Fi LMAC ROM patch.
-		 * Temporary FPGA/bring-up placement.
-		 */
-		wifi_lmac_patch_partition: partition@2e0000 {
-			compatible = "zephyr,mapped-partition";
-			reg = <0x002e0000 DT_SIZE_K(4)>;
-		};
-
-		/*
-		 * Reserved for Wi-Fi UMAC ROM patch.
-		 * Temporary FPGA/bring-up placement.
-		 */
-		wifi_umac_patch_partition: partition@2f0000 {
-			compatible = "zephyr,mapped-partition";
-			reg = <0x002f0000 DT_SIZE_K(4)>;
-		};
-
 		storage_partition: partition@300000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";


### PR DESCRIPTION
Cherry-picking: upstream commits

Changes:

1. Disable WiFi to be booted in MCUboot code.
2. Remove BUILD_WITH_TFM and TFM_FLASH_MERGED_BINARY kconfig in defconfig as it is not needed, since it will be enabled by the build system.
3. Utilise full flash allocation for NS application, as currently it did not make full use of the NS application flash.
4. Remove Wi-Fi patch reserved area as alternative solutions will be propose in the future.
5. Reduce sram_s allocation for tfm secure to 96KiB for furtehr NS app RAM free up.

Related manifest:
https://github.com/nrfconnect/sdk-trusted-firmware-m/pull/259
https://github.com/nrfconnect/sdk-nrf/pull/29836