### PR TITLE
[nrf fromtree] samples: drivers: watchdog nrf gswdt configuration fix

### DIFF
--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -55,6 +55,13 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(andestech_atcwdt200)
 #define WDT_MAX_WINDOW 500U
 #endif
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_gswdt)
+#if !defined(CONFIG_NRFS_GSWDT_SERVICE_ENABLED)
+#define WDT_MAX_WINDOW  6000U
+#endif
+#define WDT_ALLOW_CALLBACK 0
+#define WDT_OPT            0
+#endif
 
 #ifndef WDT_ALLOW_CALLBACK
 #define WDT_ALLOW_CALLBACK 1


### PR DESCRIPTION
NRF global software watchdog do not allow callbacks and expects watchdog options to be 0. Depending on gswdt service availablity wdt max window needs to
be set to 6000ms or it can be configured when
service is available. It was missing from sample.

Signed-off-by: Łukasz Stępnicki <lukasz.stepnicki@nordicsemi.no>

(cherry picked from commit 1d63607e7120727becb74bcdb30d670a1c491281)