### PR TITLE
[Backport ncs-v3.4-branch] [nrf fromtree] drivers: watchdog: gswdt driver cleanup

### DIFF
--- a/drivers/watchdog/wdt_nrf_gswdt.c
+++ b/drivers/watchdog/wdt_nrf_gswdt.c
@@ -147,13 +147,11 @@ static int wdt_nrf_gswdt_init(const struct device *dev)
 
 	err = nrfs_backend_wait_for_connection(K_FOREVER);
 	if (err != NRFS_SUCCESS) {
-		printk("%s %s", "nrfs backend connection", "failed\n");
 		return -EIO;
 	}
 
 	err = nrfs_gswdt_init(wdt_nrf_nrfs_gswdt_handler);
 	if (err != NRFS_SUCCESS) {
-		printk("%s %s", "nrfs gswdt init", "failed\n");
 		return -EIO;
 	}
 #endif


### PR DESCRIPTION
Backport 663469c71c06d765d8a1044d079f81c9fb196950 from #4233.