### PR TITLE
[nrf fromtree] usb: device_next: cdc_ncm: Check usbd_ep_enqueue() return value

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -1044,6 +1044,7 @@ static int cdc_ncm_send(const struct device *dev, struct net_pkt *const pkt)
 	size_t len = net_pkt_get_len(pkt);
 	struct net_buf *buf;
 	union send_ntb *ntb;
+	int ret;
 
 	if (len > NET_ETH_MAX_FRAME_SIZE) {
 		LOG_WRN("Trying to send too large packet, drop");
@@ -1099,7 +1100,14 @@ static int cdc_ncm_send(const struct device *dev, struct net_pkt *const pkt)
 		udc_ep_buf_set_zlp(buf);
 	}
 
-	usbd_ep_enqueue(c_data, buf);
+	ret = usbd_ep_enqueue(c_data, buf);
+	if (ret) {
+		LOG_ERR("Failed to enqueue net_buf for 0x%02x",
+			cdc_ncm_get_bulk_in(c_data));
+		net_buf_unref(buf);
+		return ret;
+	}
+
 	k_sem_take(&data->sync_sem, K_FOREVER);
 
 	net_buf_unref(buf);


### PR DESCRIPTION

The cdc_ncm_send() function ignores the return value from usbd_ep_enqueue(). If the enqueue fails, the code proceeds to block forever on k_sem_take() waiting for a completion callback that will never arrive, causing a deadlock.

This was discovered by comparing the CDC-NCM implementation with CDC-ECM, which correctly checks the return value:

    ret = usbd_ep_enqueue(c_data, buf);
    if (ret) {
        LOG_ERR("Failed to enqueue net_buf for 0x%02x", ep);
        net_buf_unref(buf);
        return ret;
    }

The NCM driver was missing this error handling, leading to potential hangs if usbd_ep_enqueue() fails for any reason (e.g., endpoint not ready, USB disconnected, buffer issues).

Fix by checking the return value and properly cleaning up (freeing the buffer) before returning the error code to the caller.

Signed-off-by: Jay Beavers <jay@tolttechnologies.com>

(cherry picked from commit 255bccc1badd1aa06c6e5ddf5b40de8463b33f02)