### PR TITLE
[nrf fromlist] boards: nordic: nrf7120dk: Add Wi-Fi XO frequency offset

### DIFF
--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -151,6 +151,7 @@
 
 &wifi {
 	status = "okay";
+	nordic,wifi-xo-freq-offset = <0x0>;
 };
 
 &audio_auxpll {

--- a/dts/bindings/wifi/nordic,nrf7120-wifi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7120-wifi.yaml
@@ -10,3 +10,14 @@ compatible: "nordic,nrf7120-wifi"
 include:
   - "wifi-tx-power-2g.yaml"
   - "wifi-tx-power-5g.yaml"
+
+properties:
+  nordic,wifi-xo-freq-offset:
+    type: int
+    default: 0
+    description: |
+      Crystal oscillator (XO) frequency offset trim, applied by the Wi-Fi
+      firmware for frequency/temperature/voltage-dependent calibration.
+      This is a board-level value that depends on the crystal used.
+      The typical default is 0. Interpreted by the firmware as a signed
+      8-bit value.


### PR DESCRIPTION
The Wi-Fi firmware needs a crystal oscillator (XO) frequency offset trim for its calibration. This is a board-level value that depends on the crystal, so express it in devicetree rather than sourcing it from a fixed register.

Add a nordic,wifi-xo-freq-offset property to the nordic,nrf7120-wifi binding (default 0) and set it on the nRF7120 DK.

Upstream PR #: 112610


Assisted-by: Claude:claude-opus-4.8

manifest-pr-skip