### PR TITLE
[nrf fromlist] tests: drivers: spi: spi_controller_peripheral: Incorr…

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/Kconfig
+++ b/tests/drivers/spi/spi_controller_peripheral/Kconfig
@@ -18,4 +18,16 @@ config PREALLOC_BUFFERS
 		Preallocate buffers used for transaction
 		using `memory-region` property.
 
+config SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_STACK_SIZE
+	int "Test workqueue stack size"
+	default 1024
+	help
+	    Stack size for thread used to perform async API checks
+
+config SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_PRIORITY
+	int "Test workqueue priority"
+	default 10
+	help
+	    Priority for the work queue used for async testing
+
 source "Kconfig.zephyr"

--- a/tests/drivers/spi/spi_controller_peripheral/Kconfig
+++ b/tests/drivers/spi/spi_controller_peripheral/Kconfig
@@ -5,29 +5,34 @@ config TESTED_SPI_MODE
 	int "SPI mode"
 	default 0
 	help
-		SPI mode value (clock polarity and phase) used in the test.
-		0: CPOL 0 (Active high), CPHA 0 (leading)
-		1: CPOL 0 (Active high), CPHA 1 (trailing)
-		2: CPOL 1 (Active low), CPHA 0 (leading)
-		3: CPOL 1 (Active low), CPHA 1 (trailing)
+	  SPI mode value (clock polarity and phase) used in the test.
+	  0: CPOL 0 (Active high), CPHA 0 (leading)
+	  1: CPOL 0 (Active high), CPHA 1 (trailing)
+	  2: CPOL 1 (Active low), CPHA 0 (leading)
+	  3: CPOL 1 (Active low), CPHA 1 (trailing)
+
+config TEST_INCORRECT_SCK_STATE
+	bool "Incorrect SCK state"
+	help
+	  Setting this option will set SCK to the opposite state than CPOL just before transceive.
 
 config PREALLOC_BUFFERS
 	bool "Preallocate buffers"
 	default y
 	help
-		Preallocate buffers used for transaction
-		using `memory-region` property.
+	  Preallocate buffers used for transaction
+	  using `memory-region` property.
 
 config SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_STACK_SIZE
 	int "Test workqueue stack size"
 	default 1024
 	help
-	    Stack size for thread used to perform async API checks
+	  Stack size for thread used to perform async API checks
 
 config SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_PRIORITY
 	int "Test workqueue priority"
 	default 10
 	help
-	    Priority for the work queue used for async testing
+	  Priority for the work queue used for async testing
 
 source "Kconfig.zephyr"

--- a/tests/drivers/spi/spi_controller_peripheral/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi3_default_alt: spi3_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi2_default_alt: spi2_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi130_default_alt: spi130_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio7 2 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi121_default_alt: spi121_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast_spis.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast_spis.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio7 3 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spis120_default_alt: spis120_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -11,6 +11,12 @@
  * CS:   P1.03 - P1.04
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -11,6 +11,12 @@
  * CS:   P1.03 - P1.04
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/half-duplex.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/half-duplex.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/spi/spi.h>
+
+&dut_spi_dt {
+	duplex = <SPI_HALF_DUPLEX>;
+};

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -68,6 +68,11 @@ struct test_data {
 
 static struct test_data tdata;
 
+struct k_work_q spim_spis_work_q;
+
+static K_KERNEL_STACK_DEFINE(spim_spis_work_q_stack,
+			CONFIG_SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_STACK_SIZE);
+
 /* Allocate buffer from spim or spis space. */
 static uint8_t *buf_alloc(size_t len, bool spim)
 {
@@ -209,7 +214,7 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 	int srx_len;
 
 	tdata.async = async;
-	rv = k_work_schedule(&tdata.test_work, K_MSEC(10));
+	rv = k_work_schedule_for_queue(&spim_spis_work_q, &tdata.test_work, K_MSEC(10));
 	zassert_equal(rv, 1);
 
 	if (!async) {
@@ -543,6 +548,16 @@ static void after(void *not_used)
 
 static void *suite_setup(void)
 {
+	struct k_work_queue_config cfg = {
+		.name = "spim_spis_work",
+		.no_yield = false,
+	};
+
+	k_work_queue_start(&spim_spis_work_q,
+			   spim_spis_work_q_stack,
+			   K_KERNEL_STACK_SIZEOF(spim_spis_work_q_stack),
+			   CONFIG_SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_PRIORITY, &cfg);
+
 	return NULL;
 }
 

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <string.h>
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/ztest.h>
@@ -24,6 +25,10 @@
 
 #define SPIM_OP	 (SPI_OP_MODE_MASTER | SPI_MODE)
 #define SPIS_OP	 (SPI_OP_MODE_SLAVE | SPI_MODE)
+
+#if CONFIG_TEST_INCORRECT_SCK_STATE && DT_NODE_HAS_PROP(DT_PATH(zephyr_user), sck_gpios)
+static const struct gpio_dt_spec sck = GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), sck_gpios);
+#endif
 
 static struct spi_dt_spec spim = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPIM_OP);
 static const struct device *spis_dev = DEVICE_DT_GET(DT_NODELABEL(dut_spis));
@@ -100,6 +105,10 @@ static void work_handler(struct k_work *work)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct test_data *td = CONTAINER_OF(dwork, struct test_data, test_work);
 	int rv;
+
+#if CONFIG_TEST_INCORRECT_SCK_STATE && DT_NODE_HAS_PROP(DT_PATH(zephyr_user), sck_gpios)
+	gpio_pin_set_dt(&sck, CONFIG_TESTED_SPI_MODE > 1 ? 0 : 1);
+#endif
 
 	if (spim.config.operation & SPI_HALF_DUPLEX) {
 		spim.config.operation |= SPI_HOLD_ON_CS;
@@ -703,6 +712,10 @@ ZTEST(spi_controller_peripheral, test_half_duplex_split_peripheral_rx_buffers)
 static void before(void *not_used)
 {
 	ARG_UNUSED(not_used);
+
+#if CONFIG_TEST_INCORRECT_SCK_STATE && !DT_NODE_HAS_PROP(DT_PATH(zephyr_user), sck_gpios)
+	ztest_test_skip();
+#endif
 
 	memset(&tdata, 0, sizeof(tdata));
 	for (size_t i = 0; i < sizeof(spim_buffer); i++) {

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -55,6 +55,7 @@ static uint8_t spis_buffer[32] MEMORY_SECTION(DT_NODELABEL(dut_spis));
 struct test_data {
 	struct k_work_delayable test_work;
 	struct k_sem sem;
+	struct k_sem half_duplex_sem;
 	int spim_alloc_idx;
 	int spis_alloc_idx;
 	struct spi_buf_set sets[4];
@@ -99,7 +100,24 @@ static void work_handler(struct k_work *work)
 	struct test_data *td = CONTAINER_OF(dwork, struct test_data, test_work);
 	int rv;
 
-	if (!td->async) {
+	if (spim.config.operation & SPI_HALF_DUPLEX) {
+		spim.config.operation |= SPI_HOLD_ON_CS;
+
+		rv = spi_write_dt(&spim, td->mtx_set);
+		spim.config.operation &= ~SPI_HOLD_ON_CS;
+		zassert_equal(rv, 0);
+
+		rv = k_sem_take(&td->half_duplex_sem, K_MSEC(1));
+		if (rv) {
+			return;
+		}
+
+		rv = spi_read_dt(&spim, td->mrx_set);
+
+		if (rv == 0) {
+			k_sem_give(&td->sem);
+		}
+	} else if (!td->async) {
 		rv = spi_transceive_dt(&spim, td->mtx_set, td->mrx_set);
 		if (rv == 0) {
 			k_sem_give(&td->sem);
@@ -213,6 +231,11 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 	int periph_rv;
 	int srx_len;
 
+	if (spim.config.operation & SPI_HALF_DUPLEX) {
+		ztest_test_skip();
+		return;
+	}
+
 	tdata.async = async;
 	rv = k_work_schedule_for_queue(&spim_spis_work_q, &tdata.test_work, K_MSEC(10));
 	zassert_equal(rv, 1);
@@ -255,6 +278,7 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 	zassert_equal(rv, 0);
 
 	rv = check_buffers(tdata.stx_set, tdata.mrx_set, s_same_size);
+	TC_PRINT("stx check same size? %d is %d\n", s_same_size, rv);
 	zassert_equal(rv, 0);
 }
 
@@ -523,6 +547,158 @@ ZTEST(spi_controller_peripheral, test_only_rx_in_chunks_async)
 	test_only_rx_in_chunks(true);
 }
 
+static void run_half_duplex_test(int len)
+{
+	int rv;
+	int periph_rv;
+	struct spi_config spis_half_duplex_config = spis_config;
+
+	if (!(spim.config.operation & SPI_HALF_DUPLEX)) {
+		ztest_test_skip();
+		return;
+	}
+
+	spis_half_duplex_config.operation |= (SPI_HOLD_ON_CS | SPI_HALF_DUPLEX);
+
+	tdata.async = false;
+	rv = k_work_schedule_for_queue(&spim_spis_work_q, &tdata.test_work, K_MSEC(10));
+	zassert_equal(rv, 1);
+
+	periph_rv = spi_read(spis_dev, &spis_half_duplex_config, tdata.srx_set);
+
+	TC_PRINT("Read %d\n", periph_rv);
+
+	if (periph_rv == -ENOTSUP) {
+		ztest_test_skip();
+		return;
+	}
+
+	zassert_equal(periph_rv, len);
+
+	k_sem_give(&tdata.half_duplex_sem);
+
+	TC_PRINT("WRITING!\n");
+
+	periph_rv = spi_write(spis_dev, &spis_half_duplex_config, tdata.stx_set);
+
+	TC_PRINT("Write %d\n", periph_rv);
+
+	if (periph_rv == -ENOTSUP) {
+		ztest_test_skip();
+		return;
+	}
+
+	rv = k_sem_take(&tdata.sem, K_MSEC(100));
+	zassert_equal(rv, 0);
+
+	zassert_equal(periph_rv, 0);
+
+	rv = check_buffers(tdata.mtx_set, tdata.srx_set, true);
+	zassert_equal(rv, 0);
+
+	rv = check_buffers(tdata.stx_set, tdata.mrx_set, true);
+	zassert_equal(rv, 0);
+
+}
+
+ZTEST(spi_controller_peripheral, test_half_duplex)
+{
+	size_t len = 16;
+
+	for (int i = 0; i < 4; i++) {
+		tdata.bufs[i].buf = buf_alloc(len, i < 2);
+		tdata.bufs[i].len = len;
+		tdata.sets[i].buffers = &tdata.bufs[i];
+		tdata.sets[i].count = 1;
+	}
+
+	tdata.mtx_set = &tdata.sets[0];
+	tdata.mrx_set = &tdata.sets[1];
+	tdata.stx_set = &tdata.sets[2];
+	tdata.srx_set = &tdata.sets[3];
+
+	run_half_duplex_test(len);
+}
+
+static void setup_split_buffer(uint8_t len)
+{
+	tdata.bufs[0].buf = buf_alloc(len / 2, true);
+	tdata.bufs[0].len = len / 2;
+	tdata.bufs[1].buf = buf_alloc(len / 2, true);
+	tdata.bufs[1].len = len / 2;
+	tdata.bufs[2].buf = buf_alloc(len, true);
+	tdata.bufs[2].len = len;
+	tdata.bufs[3].buf = buf_alloc(len, false);
+	tdata.bufs[3].len = len;
+	tdata.bufs[4].buf = buf_alloc(len, false);
+	tdata.bufs[4].len = len;
+
+	tdata.sets[0].buffers = &tdata.bufs[0];
+	tdata.sets[0].count = 2;
+
+	for (int i = 1; i < 4; i++) {
+		tdata.sets[i].buffers = &tdata.bufs[i+1];
+		tdata.sets[i].count = 1;
+	}
+}
+
+ZTEST(spi_controller_peripheral, test_half_duplex_split_controller_tx_buffers)
+{
+	size_t len = 16;
+
+	setup_split_buffer(len);
+
+	tdata.mtx_set = &tdata.sets[0];
+	tdata.mrx_set = &tdata.sets[1];
+	tdata.stx_set = &tdata.sets[2];
+	tdata.srx_set = &tdata.sets[3];
+
+	run_half_duplex_test(len);
+}
+
+ZTEST(spi_controller_peripheral, test_half_duplex_split_controller_rx_buffers)
+{
+	size_t len = 16;
+
+	setup_split_buffer(len);
+
+	tdata.mtx_set = &tdata.sets[1];
+	tdata.mrx_set = &tdata.sets[0];
+	tdata.stx_set = &tdata.sets[2];
+	tdata.srx_set = &tdata.sets[3];
+
+	run_half_duplex_test(len);
+}
+
+
+ZTEST(spi_controller_peripheral, test_half_duplex_split_peripheral_tx_buffers)
+{
+	size_t len = 16;
+
+	setup_split_buffer(len);
+
+	tdata.mtx_set = &tdata.sets[1];
+	tdata.mrx_set = &tdata.sets[2];
+	tdata.stx_set = &tdata.sets[0];
+	tdata.srx_set = &tdata.sets[3];
+
+	run_half_duplex_test(len);
+}
+
+ZTEST(spi_controller_peripheral, test_half_duplex_split_peripheral_rx_buffers)
+{
+	size_t len = 16;
+
+	setup_split_buffer(len);
+
+	tdata.mtx_set = &tdata.sets[1];
+	tdata.mrx_set = &tdata.sets[2];
+	tdata.stx_set = &tdata.sets[3];
+	tdata.srx_set = &tdata.sets[0];
+
+	run_half_duplex_test(len);
+}
+
 static void before(void *not_used)
 {
 	ARG_UNUSED(not_used);
@@ -537,6 +713,7 @@ static void before(void *not_used)
 
 	k_work_init_delayable(&tdata.test_work, work_handler);
 	k_sem_init(&tdata.sem, 0, 1);
+	k_sem_init(&tdata.half_duplex_sem, 0, 1);
 }
 
 static void after(void *not_used)

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -30,6 +30,7 @@ static const struct device *spis_dev = DEVICE_DT_GET(DT_NODELABEL(dut_spis));
 static const struct spi_config spis_config = {
 	.operation = SPIS_OP,
 	.slave = DT_PROP_OR(DT_PATH(zephyr_user), peripheral_cs, 0),
+	.frequency = DT_PROP(DT_NODELABEL(dut_spi_dt), spi_max_frequency),
 };
 
 static struct k_poll_signal async_sig = K_POLL_SIGNAL_INITIALIZER(async_sig);

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -80,6 +80,20 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
 
+  drivers.spi.spi_half_duplex:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="half-duplex.overlay"
+    platform_exclude:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54h20dk/nrf54h20/cpuppr
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+      - nrf7120dk/nrf7120/cpuapp
+      - ophelia4ev/nrf54l15/cpuapp
+
   drivers.spi.spi_fast:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     platform_exclude:

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -48,6 +48,38 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
 
+  drivers.spi.spi_mode0.incorrect_sck_state:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=0
+      - CONFIG_TEST_INCORRECT_SCK_STATE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="250khz.overlay"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+
+  drivers.spi.spi_mode1.incorrect_sck_state:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=1
+      - CONFIG_TEST_INCORRECT_SCK_STATE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="500khz.overlay"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+
+  drivers.spi.spi_mode2.incorrect_sck_state:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=2
+      - CONFIG_TEST_INCORRECT_SCK_STATE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="1mhz.overlay"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+
+  drivers.spi.spi_mode3.incorrect_sck_state:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=3
+      - CONFIG_TEST_INCORRECT_SCK_STATE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="2mhz.overlay"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+
   drivers.spi.spi_1M333333Hz:
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=0


### PR DESCRIPTION
…ect SCK

Added a set of test cases to verify the SPI controller's behavior when the SCK line is in an incorrect state (the opposite of the CPOL setting) just before transmission. These tests will be skipped if the GPIO SCK is not defined in the device tree.

Upstream PR #: 112705