### PR TITLE
[nrf fromlist] dfu: Fix mcuboot shell command

### DIFF
--- a/subsys/dfu/boot/mcuboot_priv.h
+++ b/subsys/dfu/boot/mcuboot_priv.h
@@ -10,7 +10,7 @@
 
 #include <zephyr/storage/flash_map.h>
 
-#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && (CONFIG_TFM_MCUBOOT_IMAGE_NUMBER == 2)
 #define SLOT0_LABEL	slot0_ns_partition
 #define SLOT1_LABEL	slot1_ns_partition
 #else


### PR DESCRIPTION
Fix MCUboot shell command for TFM-merged slot builds. In such case, the MCUboot header is placed at the end of `slot*_partition` instead of the `slot*_ns_partition`.

Upstream PR #: 112882