### PR TITLE
 [nrf fromlist] manifest: bump Mbed TLS to v4.1.1 and TF-PSA-Crypto to v1.1.1

### DIFF
--- a/subsys/secure_storage/Kconfig.its_transform
+++ b/subsys/secure_storage/Kconfig.its_transform
@@ -78,6 +78,7 @@ config SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER_DEVICE_ID_HASH
 
 config SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER_ENTRY_UID_HASH
 	bool "Hash of the ITS entry UID (not secure)"
+	select NOT_SECURE
 	select PSA_WANT_ALG_SHA_256
 	help
 	  This key provider generates keys by hashing the UID of the ITS entry for which it is

--- a/subsys/secure_storage/src/its/transform/aead_get.c
+++ b/subsys/secure_storage/src/its/transform/aead_get.c
@@ -4,6 +4,7 @@
 #include <zephyr/secure_storage/its/transform/aead_get.h>
 #include <zephyr/drivers/hwinfo.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <psa/crypto.h>
 #include <string.h>
@@ -123,14 +124,17 @@ SYS_INIT(warn_insecure_key, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
 psa_status_t secure_storage_its_transform_aead_get_nonce(
 		uint8_t nonce[static CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NONCE_SIZE])
 {
-	psa_status_t ret;
+	psa_status_t ret = PSA_SUCCESS;
 	static uint8_t s_nonce[CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NONCE_SIZE];
 	static bool s_nonce_initialized;
+	static K_MUTEX_DEFINE(s_nonce_mutex);
+
+	k_mutex_lock(&s_nonce_mutex, K_FOREVER);
 
 	if (!s_nonce_initialized) {
 		ret = psa_generate_random(s_nonce, sizeof(s_nonce));
 		if (ret != PSA_SUCCESS) {
-			return ret;
+			goto exit;
 		}
 		s_nonce_initialized = true;
 	} else {
@@ -141,8 +145,10 @@ psa_status_t secure_storage_its_transform_aead_get_nonce(
 			}
 		}
 	}
-
 	memcpy(nonce, &s_nonce, sizeof(s_nonce));
-	return PSA_SUCCESS;
+
+exit:
+	k_mutex_unlock(&s_nonce_mutex);
+	return ret;
 }
 #endif /* CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NONCE_PROVIDER_DEFAULT */

--- a/west.yml
+++ b/west.yml
@@ -389,7 +389,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: efdf9e209cc3b2c7be93ac81c7c96cd2550bbe27
+      revision: 2d881593696aec687ca2246c53de207c2b9bf782
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto

--- a/west.yml
+++ b/west.yml
@@ -324,7 +324,7 @@ manifest:
       revision: 85aa60d18b3d5e5588d7b247abf90198f07c8a63
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 554163f6f7b2ec71fed9b423e81f2217a8615d29
+      revision: 098e120afb51877ed814bdc04443890ae12e0642
       path: modules/crypto/mbedtls
       groups:
         - crypto
@@ -389,7 +389,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: 2d881593696aec687ca2246c53de207c2b9bf782
+      revision: fa92349590a54959ee2efc21b668e5afdb144726
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto


### PR DESCRIPTION
At the same time slip in a small Secure Storage fix.

manifest-pr-skip