### PR TITLE
[nrf fromtree] twister: expand module directory variables in path fields

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -28,6 +28,7 @@ from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
 from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
 from twisterlib.handlers import DeviceHandler, Handler, terminate_process
 from twisterlib.harnessconfig import TWISTER_PYTEST_CONFIG_FILE, HarnessPytestConfig
+from twisterlib.modulevars import expand_zephyr_vars
 from twisterlib.reports import ReportStatus
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
@@ -590,7 +591,10 @@ class Pytest(Script):
         command.extend(
             [
                 os.path.normpath(
-                    os.path.join(self.source_dir, os.path.expanduser(os.path.expandvars(src)))
+                    os.path.join(
+                        self.source_dir,
+                        expand_zephyr_vars(os.path.expanduser(os.path.expandvars(src))),
+                    )
                 )
                 for src in config.pytest_root
             ]

--- a/scripts/pylib/twister/twisterlib/modulevars.py
+++ b/scripts/pylib/twister/twisterlib/modulevars.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Expansion of Zephyr module directory / name variables in path strings.
+
+These mirror the CMake variables that the build system defines for every
+Zephyr module, so the same ${ZEPHYR_<MODULE>_MODULE_DIR} spelling can be used
+in both CMake and Twister test configuration contexts.
+"""
+
+import os
+import re
+from functools import cache
+
+import zephyr_module
+from twisterlib.constants import ZEPHYR_BASE
+
+# Matches ${NAME} or $NAME references used when expanding path variables.
+_VAR_REF_RE = re.compile(r'\$\{(?P<braced>\w+)\}|\$(?P<bare>\w+)')
+
+
+@cache
+def get_module_dir_vars() -> dict[str, str]:
+    """Return a mapping of Zephyr module directory / name variables.
+
+    For every discovered Zephyr module this provides the
+    ZEPHYR_<MODULE>_MODULE_DIR and ZEPHYR_<MODULE>_MODULE_NAME entries,
+    mirroring the CMake variables defined for each module in
+    cmake/modules/zephyr_module.cmake. The module name is sanitized and
+    upper-cased exactly as the build system does, so the same
+    ${ZEPHYR_<MODULE>_MODULE_DIR} spelling works in both CMake and
+    Twister contexts.
+    """
+    module_vars = {}
+    for module in zephyr_module.parse_modules(ZEPHYR_BASE):
+        name_upper = module.meta['name-sanitized'].upper()
+        module_vars[f'ZEPHYR_{name_upper}_MODULE_DIR'] = os.path.normpath(module.project)
+        module_vars[f'ZEPHYR_{name_upper}_MODULE_NAME'] = module.meta['name']
+    return module_vars
+
+
+def expand_zephyr_vars(path: str) -> str:
+    """Expand Zephyr module directory / name variables in a path.
+
+    Substitutes ZEPHYR_<MODULE>_MODULE_DIR and ZEPHYR_<MODULE>_MODULE_NAME,
+    which are CMake variables not present in the process environment and are
+    therefore not handled by os.path.expandvars. Unknown references are left
+    untouched. Environment variables should be expanded with os.path.expandvars
+    before calling this function.
+    """
+    if '$' not in path:
+        return path
+
+    module_vars = get_module_dir_vars()
+
+    def replace(match: re.Match) -> str:
+        name = match.group('braced') or match.group('bare')
+        return module_vars.get(name, match.group(0))
+
+    return _VAR_REF_RE.sub(replace, path)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -38,6 +38,7 @@ from twisterlib.config_parser import TwisterConfigParser
 from twisterlib.environment import TwisterEnv
 from twisterlib.error import TwisterRuntimeError
 from twisterlib.hardwaremap import HardwareMap
+from twisterlib.modulevars import expand_zephyr_vars
 from twisterlib.platform import Platform, generate_platforms
 from twisterlib.quarantine import Quarantine
 from twisterlib.statuses import TwisterStatus
@@ -683,7 +684,7 @@ class TestPlan:
                 if req_app.application not in self.testsuites:
                     required_apps.add(req_app.application)
                     if req_app.path:
-                        req_app_path = os.path.expandvars(req_app.path)
+                        req_app_path = expand_zephyr_vars(os.path.expandvars(req_app.path))
                         if os.path.isabs(req_app_path):
                             testroots.add(req_app_path)
                         else:


### PR DESCRIPTION
Cherry-picked from Upstream, only changes in Twister, required for https://github.com/nrfconnect/sdk-nrf/pull/30024

Twister resolves filesystem paths from test YAML through os.path.expandvars(), which only substitutes process environment variables. The most useful pointer to a module's root, ZEPHYR_<MODULE>_MODULE_DIR, is a CMake build-system variable and is not available at test-discovery time.

Add a helper that expands ZEPHYR_<MODULE>_MODULE_DIR and ZEPHYR_<MODULE>_MODULE_NAME, mirroring the CMake variables defined for every module, with the name sanitized and upper-cased exactly as the build system does. Apply it when resolving required_applications and required_devices paths and pytest_root, so the same spelling works in both CMake and Twister contexts.

Signed-off-by: Grzegorz Chwierut <grzegorz.chwierut@nordicsemi.no>

(cherry picked from commit 3a36fc670f5b35407dcc526e5af603c80b0bf7d9)