### PR TITLE
[nrf fromlist] soc: nordic: nrf71: don't auto-boot Wi-Fi core by default

### DIFF
--- a/soc/nordic/nrf71/Kconfig
+++ b/soc/nordic/nrf71/Kconfig
@@ -35,11 +35,14 @@ config SOC_NRF71_WIFI_DAP
 
 config SOC_NRF71_WIFI_BOOT
 	bool "nRF71 start Wi-Fi on system initialization"
-	default y if !BUILD_WITH_TFM
 	help
 	  This controls whether the Wi-Fi core is started on system initialization. If
 	  disabled, the Wi-Fi core must be started by the application before it can be
 	  used.
+
+	  A booted Wi-Fi core is only useful together with a Wi-Fi driver, so this is
+	  disabled by default and must be enabled explicitly, either by the driver
+	  that owns the core or by the application.
 
 config SOC_NRF7120_TFM_MRAMC_SERVICE
 	bool "TF-M MRAMC service"


### PR DESCRIPTION
The Wi-Fi core (LMAC/UMAC) is kickstarted from soc_early_init_hook() when SOC_NRF71_WIFI_BOOT is set. Until now this symbol defaulted to y on non-TF-M builds, so the core was booted unconditionally even when no Wi-Fi driver was present. A booted Wi-Fi core is useless without the driver that owns it, and no such driver exists in upstream Zephyr.

Invert the control: leave SOC_NRF71_WIFI_BOOT disabled by default and turn it into a passive capability that the driver owning the core is expected to select. This way the core is booted if and only if a driver that can use it is present.

A pure-Zephyr build has no nRF71 Wi-Fi driver, so defaulting the boot off is the correct behaviour and loses nothing.

Upstream PR #: 113621

Assisted-by: Claude:claude-opus-4.8

manifest-pr-skip