### PR TITLE
soc: nordic: Add RAM3 region for memory retention management

### DIFF
--- a/soc/nordic/common/poweroff.c
+++ b/soc/nordic/common/poweroff.c
@@ -59,6 +59,9 @@ void z_sys_poweroff(void)
 #if defined(NRF_MEMORY_RAM2_SIZE)
 	ram_size += NRF_MEMORY_RAM2_SIZE;
 #endif
+#if defined(NRF_MEMORY_RAM3_SIZE)
+	ram_size += NRF_MEMORY_RAM3_SIZE;
+#endif
 
 	/* Disable retention for all memory blocks */
 	nrfx_ram_ctrl_retention_enable_set(ram_start, ram_size, false);

--- a/soc/nordic/common/reboot.c
+++ b/soc/nordic/common/reboot.c
@@ -36,6 +36,9 @@ void sys_arch_reboot(int type)
 #if defined(NRF_MEMORY_RAM2_SIZE)
 	ram_size += NRF_MEMORY_RAM2_SIZE;
 #endif
+#if defined(NRF_MEMORY_RAM3_SIZE)
+	ram_size += NRF_MEMORY_RAM3_SIZE;
+#endif
 
 	/* Power on all RAM blocks */
 	nrfx_ram_ctrl_power_enable_set(ram_start, ram_size, true);


### PR DESCRIPTION
Some nrf devices has additional RAM3 region.