### PR TITLE
[nrf fromtree] task_wdt: make hardware watchdog pause-on-debug config…

### DIFF
--- a/subsys/task_wdt/Kconfig
+++ b/subsys/task_wdt/Kconfig
@@ -66,6 +66,16 @@ config TASK_WDT_HW_FALLBACK_DELAY
 	  kernel timer. This is especially important if the hardware watchdog
 	  is clocked by an inaccurate low-speed RC oscillator.
 
+config TASK_WDT_HW_FALLBACK_PAUSE_HALTED_BY_DBG
+	bool "Pause the hardware watchdog when halted by the debugger"
+	depends on TASK_WDT_HW_FALLBACK
+	default y
+	help
+	  Configure the hardware watchdog to automatically pause when the
+	  system is halted by the debugger.
+	  Note that this feature is supported only by a subset of hardware
+	  watchdogs.
+
 config TASK_WDT_HW_FALLBACK_PAUSE_IN_SLEEP
 	bool "Pause the hardware watchdog in system sleep"
 	depends on TASK_WDT_HW_FALLBACK

--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -184,7 +184,10 @@ int task_wdt_add(uint32_t reload_period, task_wdt_callback_t callback,
 			if (!hw_wdt_started && hw_wdt_dev) {
 				/* also start fallback hw wdt */
 				wdt_setup(hw_wdt_dev,
-					WDT_OPT_PAUSE_HALTED_BY_DBG
+					0
+#ifdef CONFIG_TASK_WDT_HW_FALLBACK_PAUSE_HALTED_BY_DBG
+					| WDT_OPT_PAUSE_HALTED_BY_DBG
+#endif
 #ifdef CONFIG_TASK_WDT_HW_FALLBACK_PAUSE_IN_SLEEP
 					| WDT_OPT_PAUSE_IN_SLEEP
 #endif


### PR DESCRIPTION
…urable

Add CONFIG_TASK_WDT_HW_FALLBACK_PAUSE_HALTED_BY_DBG Kconfig option to control whether the hardware fallback watchdog is paused when the system is halted by the debugger. The option is enabled by default to preserve the previous behavior.

Previously, WDT_OPT_PAUSE_HALTED_BY_DBG was unconditionally passed to wdt_setup(), which could cause issues on hardware watchdogs that do not support this option. The flag is now conditionally compiled in, guarded by the new Kconfig symbol.

Signed-off-by: Łukasz Stępnicki <lukasz.stepnicki@nordicsemi.no>

(cherry picked from commit 0b065e4dc05b97970e89db225db540073f874a7c)