### PR TITLE
[nrf fromtree] dts: nordic: nrf54lm20: provide dedicated cpuflpr dtsi

### DIFF
--- a/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuflpr_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuflpr_common.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <vendor/nordic/nrf54lm20_a_b_cpuflpr.dtsi>
 #include "nrf54lm20dk_common.dtsi"
 
 &cpuflpr_rram {

--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuflpr.dts
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuflpr.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 
+#include <vendor/nordic/nrf54lm20a_cpuflpr.dtsi>
 #include "nrf54lm20_a_b_cpuflpr_common.dtsi"
 
 / {

--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20b_cpuflpr.dts
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20b_cpuflpr.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 
+#include <vendor/nordic/nrf54lm20b_cpuflpr.dtsi>
 #include "nrf54lm20_a_b_cpuflpr_common.dtsi"
 
 / {

--- a/dts/riscv/nordic/nrf54lm20_a_b_cpuflpr.dtsi
+++ b/dts/riscv/nordic/nrf54lm20_a_b_cpuflpr.dtsi
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nordic/nrf54lm20_a_b.dtsi>
-
 cpu: &cpuflpr {};
 
 clic: &cpuflpr_clic {};

--- a/dts/vendor/nordic/nrf54lm20_a_b_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b_cpuflpr.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nordic/nrf54lm20_a_b.dtsi>
 #include <riscv/nordic/nrf54lm20_a_b_cpuflpr.dtsi>
 
 / {

--- a/dts/vendor/nordic/nrf54lm20a_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a_cpuflpr.dtsi
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <vendor/nordic/nrf54lm20a.dtsi>
+#include <vendor/nordic/nrf54lm20_a_b_cpuflpr.dtsi>

--- a/dts/vendor/nordic/nrf54lm20b_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54lm20b_cpuflpr.dtsi
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <vendor/nordic/nrf54lm20b.dtsi>
+#include <vendor/nordic/nrf54lm20_a_b_cpuflpr.dtsi>


### PR DESCRIPTION
Added DTS include files dedicated to each SoCs
FLPR core.

Signed-off-by: Michał Stasiak <michal.stasiak@nordicsemi.no>

Upstream PR #: 109916