### PR TITLE
[nrf noup] zephyr: doc: Update nRF Cloud OTA doc

### DIFF
--- a/doc/services/device_mgmt/ota.rst
+++ b/doc/services/device_mgmt/ota.rst
@@ -19,41 +19,48 @@ same method can be used as part of OTA. The binary is first downloaded
 into an unoccupied code partition, usually named ``slot1_partition``, then
 upgraded using the :ref:`mcuboot` process.
 
-Memfault and nRF Cloud powered by Memfault
-******************************************
+nRF Cloud from Nordic Semiconductor
+***********************************
 
-`Memfault`_ is an IoT observability platform that includes OTA management.
-Devices check in with Memfault's service periodically for an OTA update, and
-when an update is available, download and install the binary.
+`nRF Cloud`_ is Nordic Semiconductor's cloud platform, providing device
+management, observability, and location services.
 
-Zephyr projects that use MCUboot and have a direct Internet connection can
-leverage the `Memfault Firmware SDK's <Memfault Firmware SDK_>`_ OTA client to
-download a payload from Memfault's OTA service, load it into the secondary
-partition, and then reboot into the new image.
-See `Memfault OTA for Zephyr documentation`_ for more details on this support
-for Zephyr projects.
+nRF Cloud provides OTA infrastructure and orchestration tools for managing
+firmware updates across a device fleet, including cohort-based deployments and
+staged rollouts. It also tracks the update process end-to-end through audit
+logs, OTA analytics, and configurable alerts.
 
-For Nordic Semiconductor cellular chip users, the Memfault
-Firmware SDK includes support for downloading the payload over a cellular
-connection using nRF Connect SDK's FOTA and downloader libraries.
-See the `Memfault Quickstart for the nRF91 Series`_ for more
-information. Zephyr projects with a Bluetooth Low Energy connection can
-leverage the `Memfault Diagnostic Service`_ (MDS) with the `Memfault iOS SDK`_
-and `Memfault Android SDK`_ to deliver the update payload to the device. For
-Nordic Semiconductor's Bluetooth Low Energy chip users, the Zephyr-based
-nRF Connect SDK provides an implementation of MDS. See the
-`nRF Connect SDK documentation on MDS`_ for more information as well as
-`nRF Cloud powered by Memfault`_ for detail on using the Memfault platform with
-Nordic Semiconductor Bluetooth Low Energy chips.
-See :ref:`external_module_memfault_firmware_sdk` for overall integration
-details and examples.
+nRF Cloud OTA support is integrated into the nRF Connect SDK and the
+`nRF Connect Device Manager mobile app`_ (available for iOS and Android). Once
+onboarded, devices check in with nRF Cloud periodically and can download and
+install available updates.
 
-.. _Memfault: https://memfault.com/
-.. _Memfault Firmware SDK: https://github.com/memfault/memfault-firmware-sdk
-.. _Memfault OTA for Zephyr documentation: https://docs.memfault.com/docs/mcu/zephyr-guide#ota
-.. _Memfault Quickstart for the nRF91 Series: https://docs.memfault.com/docs/mcu/quickstart-nrf9160
-.. _Memfault Diagnostic Service: https://docs.memfault.com/docs/mcu/mds
-.. _Memfault iOS SDK: https://github.com/memfault/memfault-cloud-ios
-.. _Memfault Android SDK: https://github.com/memfault/memfault-cloud-android
-.. _nRF Connect SDK documentation on MDS: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/bluetooth/services/mds.html
-.. _nRF Cloud powered by Memfault: https://nrfcloud.com/#/
+To get started, create an account at `nrfcloud.com <nRF Cloud_>`_.
+
+The nRF91 Series
+================
+
+Nordic cellular devices can perform OTA updates out-of-the-box via CoAP or
+HTTPS using the nRF Connect SDK and the `Memfault Firmware SDK`_.
+
+For setup instructions, see the `Quickstart Documentation for nRF91 Series`_.
+
+The nRF52, nRF53, and nRF54 Series
+==================================
+
+Nordic Bluetooth LE devices can perform OTA updates out-of-the-box using the
+Simple Management Protocol (SMP), `Memfault MCUmgr Command Group`_, and the
+`Memfault Diagnostics Service (MDS)`_. Paired with the
+`nRF Connect Device Manager mobile app`_, it checks for updates and fetches
+payloads on behalf of the device.
+
+For setup instructions, see
+`Quickstart Documentation for nRF52, nRF53, and nRF54 Series`_.
+
+.. _nRF Cloud: https://nrfcloud.com/#/
+.. _nRF Connect Device Manager mobile app: https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-Device-Manager
+.. _Memfault Firmware SDK: https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/develop/manifest/external/memfault-firmware-sdk.html#external-module-memfault-firmware-sdk
+.. _Quickstart Documentation for nRF91 Series: https://docs.nrfcloud.com/docs/mcu/quickstart-nrf9160
+.. _Memfault MCUmgr Command Group: https://docs.nrfcloud.com/docs/mcu/mcumgr
+.. _Memfault Diagnostics Service (MDS): https://docs.nrfcloud.com/docs/mcu/mds
+.. _Quickstart Documentation for nRF52, nRF53, and nRF54 Series: https://docs.nrfcloud.com/docs/mcu/quickstart-nrf5x-ncs


### PR DESCRIPTION
Update the nRF Cloud OTA documentation with a few impromvements, notably:

- Reflect the unified nRF Cloud branding
- Add sections for the nRF91 and nRF52/53/54 series docs
- Provide a clear link for getting access to a free account