### PR TITLE
Add anomalies coverage for nRF71 series

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -252,7 +252,8 @@ static void clkstarted_handle(const struct device *dev,
 			      enum clock_control_nrf_type type)
 {
 #if CONFIG_CLOCK_CONTROL_NRF_HFINT_CALIBRATION
-	if (NRF_ERRATA_DYNAMIC_CHECK(54L, 30) && (type == CLOCK_CONTROL_NRF_TYPE_HFCLK)) {
+	if ((NRF_ERRATA_DYNAMIC_CHECK(54L, 30) || NRF_ERRATA_DYNAMIC_CHECK(71, 30)) &&
+	    (type == CLOCK_CONTROL_NRF_TYPE_HFCLK)) {
 		nrf54l_errata_30_workaround();
 	}
 #endif

--- a/soc/nordic/common/vpr/soc_idle.c
+++ b/soc/nordic/common/vpr/soc_idle.c
@@ -15,7 +15,8 @@ static ALWAYS_INLINE void hibernate_dummy_write(void)
 		return;
 	}
 
-	if (NRF_ERRATA_DYNAMIC_CHECK(54H, 111) || NRF_ERRATA_DYNAMIC_CHECK(54L, 18)) {
+	if (NRF_ERRATA_DYNAMIC_CHECK(54H, 111) || NRF_ERRATA_DYNAMIC_CHECK(54L, 18) ||
+	    NRF_ERRATA_DYNAMIC_CHECK(71, 18)) {
 		*(volatile int *)0x5004C804 = 1;
 	}
 }


### PR DESCRIPTION
Add support for anomalies on nRF71 series by using solutions for nRF54L. 

Blocked on nrfx 4.5.