### PR TITLE
[nrf fromlist] modules: hal_nordic: nrfx: add nrfx_bellboard driver

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -158,6 +158,7 @@ endif()
 zephyr_library_sources_ifdef(CONFIG_NRFX_PRS     ${SRC_DIR}/prs/nrfx_prs.c)
 
 zephyr_library_sources_ifdef(CONFIG_NRFX_ADC     ${SRC_DIR}/nrfx_adc.c)
+zephyr_library_sources_ifdef(CONFIG_NRFX_BELLBOARD ${SRC_DIR}/nrfx_bellboard.c)
 zephyr_library_sources_ifdef(CONFIG_NRFX_CLOCK   ${SRC_DIR}/nrfx_clock.c)
 zephyr_library_sources_ifdef(CONFIG_NRFX_CLOCK   ${SRC_DIR}/nrfx_clock_hfclk.c)
 zephyr_library_sources_ifdef(CONFIG_NRFX_CLOCK   ${SRC_DIR}/nrfx_clock_hfclkaudio.c)

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -16,6 +16,9 @@ config NRFX_ADC
 	bool "ADC driver"
 	depends on $(dt_nodelabel_exists,adc) && SOC_SERIES_NRF51
 
+config NRFX_BELLBOARD
+	bool "BELLBOARD driver"
+
 config NRFX_CLOCK
 	bool "CLOCK driver"
 	depends on $(dt_nodelabel_exists,clock)


### PR DESCRIPTION
Allows uasge of nrfx_bellboard driver.

Signed-off-by: Michał Stasiak <michal.stasiak@nordicsemi.no>

Upstream PR #: 115026