### PR TITLE
Revert "[nrf noup] tests: secure_storage: fix test w/ ZMS backend on …

### DIFF
--- a/tests/subsys/secure_storage/psa/its/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/its/testcase.yaml
@@ -33,7 +33,6 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE=zms.overlay
       - EXTRA_CONF_FILE=\
         overlay-secure_storage.conf;overlay-store_zms.conf;overlay-transform_default.conf
-      - SB_CONFIG_PARTITION_MANAGER=n
 
   secure_storage.psa.its.secure_storage.store.zms.64-bit_uids:
     platform_allow: *zms_platform_allow


### PR DESCRIPTION
…54L15"

This reverts commit e42cabe7058a1f7004f858a9f4b22f779e8e156c.