### PR TITLE
[nrf fromtree] net: coap: client: Fix ACK/RST address on connected sockets

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -892,6 +892,31 @@ static bool find_echo_option(const struct coap_packet *response, struct coap_opt
 	return coap_find_options(response, COAP_OPTION_ECHO, option, 1);
 }
 
+/* Resolve the destination for an ACK / RST reply: use the received packet's
+ * source when the transport provided one, otherwise fall back to the request's
+ * address. Returns false if no reply should be sent (multicast group).
+ */
+static bool select_reply_addr(const struct coap_client_internal_request *internal_req,
+			      const struct net_sockaddr *from, net_socklen_t from_len,
+			      const struct net_sockaddr **to, net_socklen_t *to_len)
+{
+	if (from->sa_family != NET_AF_UNSPEC) {
+		*to = from;
+		*to_len = from_len;
+		return true;
+	}
+
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+	if (internal_req->is_mcast) {
+		return false;
+	}
+#endif
+
+	*to = net_sad(&internal_req->addr);
+	*to_len = internal_req->addrlen;
+	return true;
+}
+
 static int handle_response(struct coap_client *client, const struct net_sockaddr *addr,
 			   net_socklen_t addrlen, const struct coap_packet *response,
 			   bool response_truncated)
@@ -950,8 +975,14 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 	if (!internal_req) {
 		LOG_WRN("No matching request for response");
 		if (response_type != COAP_TYPE_ACK) {
-			/* Ignore errors, unrelated to our queries */
-			(void)send_rst(client->fd, addr, addrlen, response);
+			/* Ignore errors, unrelated to our queries. If no source address
+			 * was provided, assume the socket is connected and use the send()
+			 * path.
+			 */
+			net_socklen_t rst_addrlen =
+				(addr->sa_family != NET_AF_UNSPEC) ? addrlen : 0;
+
+			(void)send_rst(client->fd, addr, rst_addrlen, response);
 		}
 		return 0;
 	}
@@ -1007,6 +1038,9 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 
 	/* Send ack for CON */
 	if (response_type == COAP_TYPE_CON) {
+		const struct net_sockaddr *ack_addr;
+		net_socklen_t ack_addrlen;
+
 #if defined(CONFIG_COAP_CLIENT_MULTICAST)
 		if (internal_req->is_mcast) {
 			/* RFC 7252 Section 8.2: Responses to multicast requests MUST NOT be
@@ -1017,9 +1051,12 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 		}
 #endif
 		/* CON response is always a separate response, respond with empty ACK. */
-		ret = send_ack(client->fd, addr, addrlen, response, COAP_CODE_EMPTY);
-		if (ret < 0) {
-			goto fail;
+		if (select_reply_addr(internal_req, addr, addrlen, &ack_addr, &ack_addrlen)) {
+			ret = send_ack(client->fd, ack_addr, ack_addrlen, response,
+				       COAP_CODE_EMPTY);
+			if (ret < 0) {
+				goto fail;
+			}
 		}
 	}
 
@@ -1034,7 +1071,13 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 
 	if (!internal_req->request_ongoing) {
 		if (internal_req->is_observe) {
-			(void)send_rst(client->fd, addr, addrlen, response);
+			const struct net_sockaddr *rst_addr;
+			net_socklen_t rst_addrlen;
+
+			if (select_reply_addr(internal_req, addr, addrlen, &rst_addr,
+					      &rst_addrlen)) {
+				(void)send_rst(client->fd, rst_addr, rst_addrlen, response);
+			}
 			return 0;
 		}
 		LOG_DBG("Drop request, already handled");

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -75,6 +75,22 @@ static struct net_sockaddr_in mcast_address = {
 	.sin_addr = {{{224, 0, 1, 187}}},
 };
 
+static const struct net_sockaddr_in recv_src_address = {
+	.sin_family = NET_AF_INET,
+	.sin_port = 0x1600,
+	.sin_addr = {{{192, 0, 2, 1}}},
+};
+
+static void fill_recv_src_addr(struct net_sockaddr *src_addr, net_socklen_t *addrlen)
+{
+	zassert_not_null(src_addr, "Unexpected NULL source address");
+	zassert_not_null(addrlen, "Unexpected NULL source address length");
+	zassert_true(*addrlen >= sizeof(recv_src_address), "Source address buffer too small");
+
+	memcpy(src_addr, &recv_src_address, sizeof(recv_src_address));
+	*addrlen = sizeof(recv_src_address);
+}
+
 static uint16_t get_next_pending_message_id(void)
 {
 	int i;
@@ -140,6 +156,8 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake(int sock, void *buf, size_t max
 	restore_token(ack_data);
 
 	memcpy(buf, ack_data, sizeof(ack_data));
+
+	fill_recv_src_addr(src_addr, addrlen);
 
 	clear_socket_events(sock, ZSOCK_POLLIN);
 
@@ -273,9 +291,91 @@ static ssize_t z_impl_zsock_sendto_custom_fake_err(int sock, void *buf, size_t l
 	return -1;
 }
 
+static ssize_t z_impl_zsock_sendto_custom_fake_connected(int sock, void *buf, size_t len,
+							 int flags,
+							 const struct net_sockaddr *dest_addr,
+							 net_socklen_t addrlen)
+{
+	/* The request was issued without a destination address (connected
+	 * transport). Every send, including ACK/RST replies, must reuse the
+	 * connected send path rather than a source address that recvfrom() did
+	 * not populate.
+	 */
+	zassert_equal(addrlen, 0, "Connected socket send must not carry an address");
+	zassert_is_null(dest_addr, "Connected socket send must not carry an address");
+
+	return z_impl_zsock_sendto_custom_fake(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+static ssize_t z_impl_zsock_sendto_custom_fake_check_reply_addr(
+	int sock, void *buf, size_t len, int flags,
+	const struct net_sockaddr *dest_addr, net_socklen_t addrlen)
+{
+	uint8_t type = (((uint8_t *)buf)[0] & 0x30) >> 4;
+
+	/* ACK/RST replies must be addressed to the source of the received
+	 * packet when the transport reported one.
+	 */
+	if (type == COAP_TYPE_ACK || type == COAP_TYPE_RESET) {
+		zassert_equal(addrlen, sizeof(recv_src_address),
+			      "Reply not addressed to received source");
+		zassert_mem_equal(dest_addr, &recv_src_address, sizeof(recv_src_address),
+				  "Reply not addressed to received source");
+	}
+
+	return z_impl_zsock_sendto_custom_fake(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+static ssize_t z_impl_zsock_sendto_custom_fake_check_req_addr(
+	int sock, void *buf, size_t len, int flags,
+	const struct net_sockaddr *dest_addr, net_socklen_t addrlen)
+{
+	uint8_t type = (((uint8_t *)buf)[0] & 0x30) >> 4;
+
+	/* recvfrom() reported no source, so an ACK/RST reply must fall back to
+	 * the address the request was sent to, not a zeroed one.
+	 */
+	if (type == COAP_TYPE_ACK || type == COAP_TYPE_RESET) {
+		zassert_equal(addrlen, sizeof(struct net_sockaddr_in),
+			      "Reply not addressed to request address");
+		zassert_mem_equal(dest_addr, &dst_address, sizeof(struct net_sockaddr_in),
+				  "Reply not addressed to request address");
+	}
+
+	return z_impl_zsock_sendto_custom_fake(sock, buf, len, flags, dest_addr, addrlen);
+}
+
 static ssize_t z_impl_zsock_recvfrom_custom_fake_response(int sock, void *buf, size_t max_len,
 							  int flags, struct net_sockaddr *src_addr,
 							  net_socklen_t *addrlen)
+{
+	uint16_t last_message_id = 0;
+
+	static uint8_t ack_data[] = {0x48, 0x45, 0x00, 0x00, 0x00, 0x00,
+				     0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+	last_message_id = get_next_pending_message_id();
+
+	ack_data[2] = (uint8_t)(last_message_id >> 8);
+	ack_data[3] = (uint8_t)last_message_id;
+	restore_token(ack_data);
+
+	memcpy(buf, ack_data, sizeof(ack_data));
+
+	fill_recv_src_addr(src_addr, addrlen);
+
+	clear_socket_events(sock, ZSOCK_POLLIN);
+
+	return sizeof(ack_data);
+}
+
+/* CON response like z_impl_zsock_recvfrom_custom_fake_response, but modelling a
+ * connected transport that does not report a per-packet source address.
+ * src_addr/addrlen are deliberately left untouched.
+ */
+static ssize_t z_impl_zsock_recvfrom_custom_fake_connected(int sock, void *buf, size_t max_len,
+							   int flags, struct net_sockaddr *src_addr,
+							   net_socklen_t *addrlen)
 {
 	uint16_t last_message_id = 0;
 
@@ -311,6 +411,8 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_empty_ack(int sock, void *buf, 
 
 	memcpy(buf, ack_data, sizeof(ack_data));
 
+	fill_recv_src_addr(src_addr, addrlen);
+
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_response;
 
 	return sizeof(ack_data);
@@ -331,6 +433,9 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_rst(int sock, void *buf, size_t
 	rst_data[3] = (uint8_t)last_message_id;
 
 	memcpy(buf, rst_data, sizeof(rst_data));
+
+	fill_recv_src_addr(src_addr, addrlen);
+
 	clear_socket_events(sock, ZSOCK_POLLIN);
 
 	return sizeof(rst_data);
@@ -366,6 +471,8 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_unmatching(int sock, void *buf,
 
 	memcpy(buf, ack_data, sizeof(ack_data));
 
+	fill_recv_src_addr(src_addr, addrlen);
+
 	clear_socket_events(sock, ZSOCK_POLLIN);
 
 	return sizeof(ack_data);
@@ -389,6 +496,8 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_echo(int sock, void *buf, size_
 	restore_token(ack_data);
 
 	memcpy(buf, ack_data, sizeof(ack_data));
+
+	fill_recv_src_addr(src_addr, addrlen);
 
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_response;
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_echo;
@@ -417,6 +526,8 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_echo_next_req(int sock, void *b
 	restore_token(ack_data);
 
 	memcpy(buf, ack_data, sizeof(ack_data));
+
+	fill_recv_src_addr(src_addr, addrlen);
 
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_response;
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_echo_next_req;
@@ -673,6 +784,63 @@ ZTEST(coap_client, test_separate_response_ack_fail)
 
 	zassert_ok(k_sem_take(&sem1, K_MSEC(COAP_SEPARATE_TIMEOUT)));
 	zassert_equal(last_response_code, -ENETDOWN, "");
+}
+
+ZTEST(coap_client, test_separate_response_connected)
+{
+	struct coap_client_request req = short_request;
+
+	req.user_data = &sem1;
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_connected;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_connected;
+
+	/* addr == NULL models a connected transport that does not report a
+	 * per-packet source address on recvfrom(). The empty ACK sent for the
+	 * CON response must therefore be sent on the connected socket, which
+	 * z_impl_zsock_sendto_custom_fake_connected asserts.
+	 */
+	zassert_ok(coap_client_req(&client, 0, NULL, &req, NULL));
+
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
+}
+
+ZTEST(coap_client, test_separate_response_reply_to_source)
+{
+	struct coap_client_request req = short_request;
+
+	req.user_data = &sem1;
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_check_reply_addr;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_response;
+
+	/* Connectionless transport: recvfrom() reports the source, so the empty
+	 * ACK for the CON response must be addressed to that source.
+	 */
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
+}
+
+ZTEST(coap_client, test_separate_response_req_addr_no_src)
+{
+	struct coap_client_request req = short_request;
+
+	req.user_data = &sem1;
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_check_req_addr;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_connected;
+
+	/* The request provides a destination address, but recvfrom() reports no
+	 * source (connected socket used with an explicit peer). The ACK must
+	 * fall back to the request's address rather than a bogus one.
+	 */
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 }
 
 ZTEST(coap_client, test_multiple_requests)


### PR DESCRIPTION
Fixes upstream bug report about coap_client issues with nRF9x sockets: https://github.com/zephyrproject-rtos/zephyr/issues/115075