### PR TITLE
[nrf fromlist] drivers: mbox: nrf_vevif_event: allow early interrupt …

### DIFF
--- a/drivers/mbox/Kconfig.nrf_vevif_event
+++ b/drivers/mbox/Kconfig.nrf_vevif_event
@@ -15,7 +15,15 @@ config MBOX_NRF_VEVIF_EVENT_TX
 	help
 	  Mailbox driver for transmitting events from VPR to a remote core
 
+config MBOX_NRF_VEVIF_EVENT_EARLY_INT_HANDLE
+	bool "Early interrupt handling"
+	help
+	  Enable handling of early interrupts that arrive before
+	  VPR event is enabled. Pending interrupt will be handled after
+	  enabling corresponding event.
+
 config MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16
 	bool "Apply errata 16 for nRF54L series"
 	depends on SOC_NRF54L05 || SOC_NRF54L10 || SOC_NRF54L15
+	select MBOX_NRF_VEVIF_EVENT_EARLY_INT_HANDLE
 	default y

--- a/drivers/mbox/mbox_nrf_vevif_event_rx.c
+++ b/drivers/mbox/mbox_nrf_vevif_event_rx.c
@@ -24,14 +24,14 @@ struct mbox_vevif_event_rx_cbs {
 	mbox_callback_t cb[EVENTS_IDX_MAX - EVENTS_IDX_MIN + 1U];
 	void *user_data[EVENTS_IDX_MAX - EVENTS_IDX_MIN + 1U];
 	uint32_t enabled_mask;
-#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16)
+#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_EARLY_INT_HANDLE)
 	bool pending_irq;
 #endif
 };
 
 struct mbox_vevif_event_rx_conf {
 	NRF_VPR_Type *vpr;
-#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16)
+#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_EARLY_INT_HANDLE)
 	IRQn_Type irqn;
 #endif
 	uint32_t events_mask;
@@ -44,7 +44,7 @@ static void trigger_callback(const struct device *dev, struct mbox_vevif_event_r
 {
 	uint8_t idx = id - EVENTS_IDX_MIN;
 
-#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16)
+#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_EARLY_INT_HANDLE)
 	if (cbs->enabled_mask == 0) {
 		cbs->pending_irq = true;
 		return;
@@ -122,7 +122,7 @@ static int vevif_event_rx_set_enabled(const struct device *dev, uint32_t id, boo
 		}
 
 		cbs->enabled_mask |= BIT(id);
-#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16)
+#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_EARLY_INT_HANDLE)
 		if (cbs->pending_irq) {
 			NRFX_IRQ_PENDING_SET(config->irqn);
 		}
@@ -135,7 +135,7 @@ static int vevif_event_rx_set_enabled(const struct device *dev, uint32_t id, boo
 		}
 
 		cbs->enabled_mask &= ~BIT(id);
-#if !defined(CONFIG_MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16)
+#if !defined(CONFIG_MBOX_NRF_VEVIF_EVENT_EARLY_INT_HANDLE)
 		nrfy_vpr_int_disable(config->vpr, BIT(id));
 #endif
 	}
@@ -155,7 +155,7 @@ static int vevif_event_rx_init(const struct device *dev)
 
 	config->irq_connect();
 
-#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16)
+#if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_EARLY_INT_HANDLE)
 	/* Only one event is used anyway so all can be enabled. Interrupt is enabled
 	 * here because workaround works in a way that event triggered when interrupts
 	 * are enabled would be lost. Interrupts are enabled from the start and if
@@ -188,7 +188,7 @@ static int vevif_event_rx_init(const struct device *dev)
 		.events = DT_INST_PROP(inst, nordic_events),                                       \
 		.events_mask = DT_INST_PROP(inst, nordic_events_mask),                             \
 		.irq_connect = irq_connect##inst,                                                  \
-		IF_ENABLED(CONFIG_MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16,                          \
+		IF_ENABLED(CONFIG_MBOX_NRF_VEVIF_EVENT_EARLY_INT_HANDLE,                           \
 				(.irqn = DT_IRQN(DT_DRV_INST(inst))))                              \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/mbox/mbox_nrf_vevif_event_rx.c
+++ b/drivers/mbox/mbox_nrf_vevif_event_rx.c
@@ -193,6 +193,7 @@ static int vevif_event_rx_init(const struct device *dev)
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, vevif_event_rx_init, NULL, &data##inst, &conf##inst,           \
-			      POST_KERNEL, CONFIG_MBOX_INIT_PRIORITY, &vevif_event_rx_driver_api);
+			      POST_KERNEL, UTIL_INC(CONFIG_NORDIC_VPR_LAUNCHER_INIT_PRIORITY),     \
+			      &vevif_event_rx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VEVIF_EVENT_RX_DEFINE)

--- a/drivers/misc/nordic_vpr_launcher/Kconfig
+++ b/drivers/misc/nordic_vpr_launcher/Kconfig
@@ -19,6 +19,12 @@ source "subsys/logging/Kconfig.template.log_config"
 config NORDIC_VPR_LAUNCHER_INIT_PRIORITY
 	int "Nordic VPR coprocessor launcher init priority"
 	default 44 if DT_HAS_NORDIC_CORESIGHT_NRF_ENABLED
+	# If errata 16 is enabled Mailbox driver need to be started as soon as possible
+	# after VPR launcher to minimize a chance of losing an event from FLPR.
+	# Mailbox starts one level later than the VPR launcher and as many modules
+	# may start on level 0 there might be a significant delay. Need to use less common
+	# level. It's not bullet proof but there is nothing better.
+	default 11 if MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16
 	default 0
 	help
 	  The init priority of the VPR coprocessor launcher.


### PR DESCRIPTION
…handling

Mechanism of early interrupt handling introduced for nRF54L errata 16 can be used even if the anomaly
itself is not present on a chip.
It can solve the issue of missed events from early booting VPR core.

Signed-off-by: Michał Stasiak <michal.stasiak@nordicsemi.no>

Upstream PR #: 116162